### PR TITLE
Make defaultOptions within the InfluxDB scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,20 +3,19 @@ var influxRequest = require('./lib/InfluxRequest.js');
 var url           = require('url');
 var _             = require('underscore');
 
-var defaultOptions = {
-  hosts               : [],
-  disabled_hosts      : [],
-  username            : 'root',
-  password            : 'root',
-  port                : 8086,
-  depreciatedLogging  : (process.env.NODE_ENV === undefined || 'development') ? console.log : false,
-  failoverTimeout     : 60000,
-  requestTimeout      : null,
-  maxRetries          : 2
-};
-
 var InfluxDB = function(options) {
 
+  var defaultOptions = {
+    hosts               : [],
+    disabled_hosts      : [],
+    username            : 'root',
+    password            : 'root',
+    port                : 8086,
+    depreciatedLogging  : (process.env.NODE_ENV === undefined || 'development') ? console.log : false,
+    failoverTimeout     : 60000,
+    requestTimeout      : null,
+    maxRetries          : 2
+  };
 
   this.options = _.extend(defaultOptions,options);
 


### PR DESCRIPTION
The defaultOptions value is within the global scope, which causes problems if you want more than one InfluxDB instance per node process. 

Take this code, for example:

```
#!/usr/bin/env coffee
influx = require "influx"

first_client = influx
  database: "first_database"

console.log first_client.options.database

second_client = influx
  database: "second_database"

console.log "------"
console.log first_client.options.database
console.log second_client.options.database
```

The result will print out four lines. When defaultOptions is in the global scope, the output looks like this:

```
first_database
------
second_database
second_database
```

This is alarming because the first instance of InfluxDB will actually query against the **second** database!

When using this PR, the output is now as you'd expect, which will allow you to connect to multiple InfluxDB databases within the same node process:

```
first_database
------
first_database
second_database
```
