### PR TITLE
time_precision should be ms, not m

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ InfluxDB.prototype.writeSeries = function(series, options, callback) {
         var v = typeof values[k] === 'undefined' ? null : values[k];
         if(k === 'time' && v instanceof Date) {
           v = v.valueOf();
-          query.time_precision = 'm';
+          query.time_precision = 'ms';
         }
         point.push(v);
       });


### PR DESCRIPTION
using {value: v, time: new Date()}, this is spit out in the influx logs

[WARN] time_precision=m will be disabled in future release, use time_precision=ms instead
