### PR TITLE
use ms instead of m as time precision,

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ InfluxDB.prototype.writeSeries = function(series, options, callback) {
         var v = typeof values[k] === 'undefined' ? null : values[k];
         if(k === 'time' && v instanceof Date) {
           v = v.valueOf();
-          query.time_precision = 'm';
+          query.time_precision = 'ms';
         }
         point.push(v);
       });


### PR DESCRIPTION
 'm' is deprecated and results in log warnings from influxdb
