### PR TITLE
Allow query responses to be streamed

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,11 +235,11 @@ InfluxDB.prototype.query = function(query, callback) {
 InfluxDB.prototype.queryStream = function(query) {
   // A streamed request forgoes any response processing by this library and
   // leaves that up to the user.
-  return this.request.stream(
+  return this.request.stream({
     url: this.url('db/' + this.options.database + '/series', { q: query }),
     method: "GET",
     json: true
-  );
+  });
 };
 
 InfluxDB.prototype.dropSeries  = function(databaseName, seriesName, callback) {

--- a/index.js
+++ b/index.js
@@ -232,6 +232,16 @@ InfluxDB.prototype.query = function(query, callback) {
   }, this._parseCallback(callback));
 };
 
+InfluxDB.prototype.queryStream = function(query) {
+  // A streamed request forgoes any response processing by this library and
+  // leaves that up to the user.
+  return this.request.stream(
+    url: this.url('db/' + this.options.database + '/series', { q: query }),
+    method: "GET",
+    json: true
+  );
+};
+
 InfluxDB.prototype.dropSeries  = function(databaseName, seriesName, callback) {
   if ('function' === typeof seriesName)
   {

--- a/lib/InfluxRequest.js
+++ b/lib/InfluxRequest.js
@@ -114,7 +114,6 @@ InfluxRequest.prototype._request = function (options, callback) {
   });
 };
 
-// Stream has no retries.
 InfluxRequest.prototype._stream = function(options) {
   var self = this;
   var host = this.getHost();
@@ -124,8 +123,12 @@ InfluxRequest.prototype._stream = function(options) {
     return callback(new Error('No host available'));
   }
 
-  var requestOptions = _.extend({host: host}, this.defaultRequestOptions, options);
+  var requestOptions = _.extend({retries: 0, host: host}, this.defaultRequestOptions, options);
 
+  //need to store the original path, in case we need to re-submit the request onError and change the host
+  if (!requestOptions.originalUrl) requestOptions.originalUrl = requestOptions.url;
+  requestOptions.url = this.url(host, requestOptions.originalUrl);
+  requestOptions.retries++;
   return request(requestOptions);
 }
 

--- a/lib/InfluxRequest.js
+++ b/lib/InfluxRequest.js
@@ -114,6 +114,21 @@ InfluxRequest.prototype._request = function (options, callback) {
   });
 };
 
+// Stream has no retries.
+InfluxRequest.prototype._stream = function(options) {
+  var self = this;
+  var host = this.getHost();
+
+  if (!host)
+  {
+    return callback(new Error('No host available'));
+  }
+
+  var requestOptions = _.extend({host: host}, this.defaultRequestOptions, options);
+
+  return request(requestOptions);
+}
+
 InfluxRequest.prototype._parseCallback = function (err, response, body, requestOptions, callback) {
 
   if (err && -1 !== resubmitErrorCodes.indexOf(err.code)) {
@@ -130,10 +145,13 @@ InfluxRequest.prototype.get = function (options, callback) {
   this._request(options, callback);
 };
 
-
 InfluxRequest.prototype.post = function (options, callback) {
   options.method = 'POST';
   this._request(options, callback);
 };
+
+InfluxRequest.prototype.stream = function(options) {
+  return this._stream(options);
+}
 
 module.exports = InfluxRequest;


### PR DESCRIPTION
My use case requires I pull large swaths of data out of InfluxDB to be stored in a file that users can later download. Under the current implementation of node-influx, the whole response body of a query would be stored in memory, which could be in the hundreds of megabytes. To combat this, I added the `queryStream` interface onto `InfluxDB` that provides direct access to the request object for streaming. I'll admit I used a bit of copy paste, but as a first pass, it was better than rearranging all your code which you might want to organize differently. 

Let me know if there's a better way to do this. Here's how I'm using it, taking the data from InfluxDB and streaming it directly to Rackspace Cloud Files:

```coffeescript
jobs.process 'generate-data', (job, done) ->
  identifier = job.data.identifier
  start_date = job.data.start_date + "000u" 
  end_date = job.data.end_date + "000u"

  writeStream = cloudfiles.upload
    container: 'mybucket'
    remote: "#{uuid.v4()}.json.gz"

  gzip = zlib.createGzip()

  writeStream.on 'error', (err) ->
    done(err)

  writeStream.on 'success', (file) ->
    done()

  query = "SELECT point from \"#{identifier}\" where time > #{start_date} and time < #{end_date}"

  req = influxClient.queryStream query
  req.on("error", (err) ->
    console.log(err)
  ).pipe(gzip).pipe(writeStream)
```