### PR TITLE
Escape strings as values when writing points

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,6 +245,16 @@ InfluxDB.prototype.dropUser = function (username, callback) {
 
 InfluxDB.prototype._createKeyValueString = function (object) {
   return _.map(object, function (value, key) {
+    if(typeof value === 'string') {
+      return key + '="' + value + '"'
+    } else {
+      return key + '=' + value
+    }
+  }).join(',')
+}
+
+InfluxDB.prototype._createKeyTagString = function (object) {
+  return _.map(object, function (value, key) {
     return key + '=' + value
   }).join(',')
 }
@@ -255,7 +265,7 @@ InfluxDB.prototype._prepareValues = function (series) {
     _.each(values, function (points) {
       var line = seriesName
       if (points[1] && _.isObject(points[1]) && _.keys(points[1]).length > 0) {
-        line += ',' + this._createKeyValueString(points[1])
+        line += ',' + this._createKeyTagString(points[1])
       }
 
       if (_.isObject(points[0])) {
@@ -273,7 +283,11 @@ InfluxDB.prototype._prepareValues = function (series) {
           }
         }
       } else {
-        line += ' value=' + points[0]
+        if(typeof points[0] === 'string') {
+          line += ' value="' + points[0] + '"'
+        } else {
+          line += ' value=' + points[0]
+        }
       }
       output.push(line)
     }, this)

--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ InfluxDB.prototype.dropUser = function (username, callback) {
 
 InfluxDB.prototype._createKeyValueString = function (object) {
   return _.map(object, function (value, key) {
-    if(typeof value === 'string') {
+    if (typeof value === 'string') {
       return key + '="' + value + '"'
     } else {
       return key + '=' + value
@@ -283,7 +283,7 @@ InfluxDB.prototype._prepareValues = function (series) {
           }
         }
       } else {
-        if(typeof points[0] === 'string') {
+        if (typeof points[0] === 'string') {
           line += ' value="' + points[0] + '"'
         } else {
           line += ' value=' + points[0]

--- a/test.js
+++ b/test.js
@@ -296,11 +296,11 @@ describe('InfluxDB', function () {
     it('should write a point with time into the database', function (done) {
       dbClient.writePoint(info.series.name, {time: new Date(), value: 232}, {}, done)
     })
-    
+
     it('should write a point with a string as value into the database', function (done) {
       dbClient.writePoint(info.series.strName, {value: 'my test string'}, {}, done)
     })
-    
+
     it('should write a point with a string as value into the database (using different method)', function (done) {
       dbClient.writePoint(info.series.strName, 'my second test string', {}, done)
     })

--- a/test.js
+++ b/test.js
@@ -23,7 +23,7 @@ describe('InfluxDB', function () {
       retentionPolicy: 'testrp'
     },
     series: {
-      name: 'response_time'
+      name: 'response_time',
       strName: 'string_test'
     }
   }

--- a/test.js
+++ b/test.js
@@ -24,6 +24,7 @@ describe('InfluxDB', function () {
     },
     series: {
       name: 'response_time'
+      strName: 'string_test'
     }
   }
 
@@ -294,6 +295,14 @@ describe('InfluxDB', function () {
 
     it('should write a point with time into the database', function (done) {
       dbClient.writePoint(info.series.name, {time: new Date(), value: 232}, {}, done)
+    })
+    
+    it('should write a point with a string as value into the database', function (done) {
+      dbClient.writePoint(info.series.strName, {value: 'my test string'}, {}, done)
+    })
+    
+    it('should write a point with a string as value into the database (using different method)', function (done) {
+      dbClient.writePoint(info.series.strName, 'my second test string', {}, done)
     })
   })
 


### PR DESCRIPTION
With the current client it is not possible to write strings because they need to be escaped properly.
See also #78.
Includes the bugfix and test.