### PR TITLE
Support separate integer and float types

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Version 3.x.x is compatible with InfluxDB 0.8.x
 
 Version 4.x.x is compatible with InfluxDB 0.9.x 
 
+Version 4.1.x is compatible with InfluxDB 0.9.3+
+
 
 ## Usage
 
@@ -194,7 +196,7 @@ client.createUser(username, password, isAdmin, function(err,response) { })
 Sets the users password - requires admin privileges
 
 ```js
-client.setPassword(username, password, function (err, reponse) {} )
+client.setPassword(username, password, function (err, response) {} )
 ```
 
 
@@ -202,34 +204,34 @@ client.setPassword(username, password, function (err, reponse) {} )
 Grants privilege for the given user - requires admin privileges
 
 ```js
-client.grantPrivilege(privilege, databaseName, userName, function (err, reponse) {} )
+client.grantPrivilege(privilege, databaseName, userName, function (err, response) {} )
 ```
 
 ##### revokePrivilege
 Revokes privilege for the given user - requires admin privileges
 
 ```js
-client.revokePrivilege(privilege, databaseName, userName, function (err, reponse) {} )
+client.revokePrivilege(privilege, databaseName, userName, function (err, response) {} )
 ```
 
 ##### grantAdminPrivileges
 Grants admin privileges for the given user - requires admin privileges
 
 ```js
-client.grantAdminPrivileges(userName, function (err, reponse) {} )
+client.grantAdminPrivileges(userName, function (err, response) {} )
 ```
 
 ##### revokeAdminPrivileges
 Revokes all admin privileges for the given user - requires admin privileges
 
 ```js
-client.revokeAdminPrivileges(userName, function (err, reponse) {} )
+client.revokeAdminPrivileges(userName, function (err, response) {} )
 ```
 
 ##### dropUser
 Drops the given user - requires admin privileges
 ```js
-client.dropUser(userName, function(err,response) {] )
+client.dropUser(userName, function(err,response) {} )
 ```
 
 
@@ -241,25 +243,34 @@ var point = { attr : value, time : new Date()};
 client.writePoint(seriesName, values, tags, [options,] function(err, response) { })
 ```
 
-`values` can be either an objekt or a single value. For the latter the columname is set to `value`.
-You can set the time by passing an object propety called `time`. The time an be either an integer value or a Date object. When providing a single value, don't forget to adjust the time precision accordingly. The default value is `ms`.
-The parameter `options` is optional and can be used to set the time precision.
+`values` can be either an object or a single value. For the latter the column name is set to `value`.
+You can set the time by passing an object property called `time`. The time an be either an integer value or a Date object. When providing a single value, don't forget to adjust the time precision accordingly. The default value is `ms`.
+The parameter `options` is optional and can be used to set the time precision or value type. Unless manually specified, all numbers will be written as InfluxDB floats.
 
 ###### example
 ```js
-//write a single point with two values and two tags. time is omitted
-client.writePoint(info.series.name, {value: 232, value2: 123}, { foo: 'bar', foobar: 'baz'}, done)
+//write a single point with two values and two tags. time is omitted.
+// The number values will be written as an InfluxDB floats.
+client.writePoint(info.series.name, {value: 232, value2: 123}, { foo: 'bar', foobar: 'baz' }, done)
 
 //write a single point with the value "1". The value "1" corresponds to { value : 1 }
-client.writePoint(info.series.name, 1, { foo: 'bar', foobar: 'baz'}, done)
+client.writePoint(info.series.name, 1, { foo: 'bar', foobar: 'baz' }, done)
 
 //write a single point, providing an integer timestamp and time precision 's' for seconds
 client.writePoint(info.series.name, {time: 1234567890, value: 232}, null, {precision : 's'}, done)
 
 //write a single point, providing a Date object. Precision is set to default 'ms' for milliseconds.
-client.writePoint(info.series.name, {time: new Date(), value: 232}, null,  done)
+client.writePoint(info.series.name, {time: new Date(), value: 232}, null, done)
 
+//write a single point using a single value (number will be written as InfluxDB float)
+client.writePoint(info.series.name, 232, null, done)
 
+//write a single point using a single value, forcing as InfluxDB integer
+client.writePoint(info.series.name, 232, null, {type: 'int'}, done)
+
+//write a single point with two values.
+// The first number value will be written as an InfluxDB float, the second as an integer.
+client.writePoint(info.series.name, {value: 232, value2: { type: 'int', value: 123 }}, done)
 ```
 
 ###### writePoints
@@ -292,7 +303,9 @@ var points = [
   //third value, passed as integer. Different tag
   [123, { foobar: 'baz'}],
   //value providing timestamp, without tags
-  [{value: 122, time : new Date()}]
+  [{value: 122, time : new Date()}],
+  //value as integer instead of float
+  [{value: { value: 23122, type: 'int' }}]
 ]
 
 var points2 = [
@@ -303,7 +316,9 @@ var points2 = [
   //third value, passed as integer. Different tag
   [12345, { foobar: 'baz'}],
   //value providing timestamp, without tags
-  [{value: 23122, time : new Date()}]
+  [{value: 23122, time : new Date()}],
+  //value as integer instead of float
+  [{value: { value: 23122, type: 'int' }}]
 ]
 var series = {
     series_name_one : points,

--- a/index.js
+++ b/index.js
@@ -245,12 +245,8 @@ InfluxDB.prototype.dropUser = function (username, callback) {
 
 InfluxDB.prototype._createKeyValueString = function (object) {
   return _.map(object, function (value, key) {
-    if (typeof value === 'string') {
-      return key + '="' + value + '"'
-    } else {
-      return key + '=' + value
-    }
-  }).join(',')
+    return this._formatKeyValueString(key, value)
+  }, this).join(',')
 }
 
 InfluxDB.prototype._createKeyTagString = function (object) {
@@ -259,22 +255,48 @@ InfluxDB.prototype._createKeyTagString = function (object) {
   }).join(',')
 }
 
-InfluxDB.prototype._prepareValues = function (series) {
+InfluxDB.prototype._formatKeyValueString = function (key, value) {
+  if (_.isObject(value)) {
+    if (value.type === 'int') {
+      return key + '=' + this._formatNumber(value.value, true)
+    }
+    return this._formatKeyValueString(key, value.value)
+  } else if (typeof value === 'string') {
+    return key + '="' + value + '"'
+  } else if (typeof value === 'number') {
+    return key + '=' + this._formatNumber(value)
+  } else {
+    return key + '=' + value
+  }
+}
+
+InfluxDB.prototype._formatNumber = function (number, asInt) {
+  if (asInt) {
+    return number.toFixed(0) + 'i'
+  }
+
+  return '' + number
+}
+
+InfluxDB.prototype._prepareValues = function (series, options) {
   var output = []
   _.forEach(series, function (values, seriesName) {
     _.each(values, function (points) {
       var line = seriesName.replace(/ /g, '\\ ').replace(/,/g, '\\,')
-      if (points[1] && _.isObject(points[1]) && _.keys(points[1]).length > 0) {
-        line += ',' + this._createKeyTagString(points[1])
+      var value = points[0]
+      var tag = points[1]
+
+      if (tag && _.isObject(tag) && _.keys(tag).length > 0) {
+        line += ',' + this._createKeyTagString(tag)
       }
 
-      if (_.isObject(points[0])) {
+      if (_.isObject(value)) {
         var timestamp = null
-        if (points[0].time) {
-          timestamp = points[0].time
-          delete (points[0].time)
+        if (value.time) {
+          timestamp = value.time
+          delete (value.time)
         }
-        line += ' ' + this._createKeyValueString(points[0])
+        line += ' ' + this._createKeyValueString(value)
         if (timestamp) {
           if (timestamp instanceof Date) {
             line += ' ' + timestamp.getTime()
@@ -283,11 +305,11 @@ InfluxDB.prototype._prepareValues = function (series) {
           }
         }
       } else {
-        if (typeof points[0] === 'string') {
-          line += ' value="' + points[0] + '"'
-        } else {
-          line += ' value=' + points[0]
+        value = { value: value }
+        if (options.type) {
+          value.type = options.type
         }
+        line += this._createKeyValueString('value', value)
       }
       output.push(line)
     }, this)
@@ -312,7 +334,7 @@ InfluxDB.prototype.writeSeries = function (series, options, callback) {
   this.request.post({
     url: this.url('write', options),
     pool: typeof options.pool !== 'undefined' ? options.pool : {},
-    body: this._prepareValues(series)
+    body: this._prepareValues(series, options)
   }, this._parseCallback(callback))
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "influx",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "InfluxDB Client",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This patch attempts to allow specifying a value as being an integer. Any numbers that aren't integers are force-written as floats. This is achieved by allowing values to be objects which define 2 properties: `type` and `value`. For single point writes that are not objects, you can specify the value as being integer through the `options`.

```js
var point = {
  fieldName: { type: 'int', value: 123 }, // written on line as 123i
  value: 123 // written on line as 123.0
  value: 123.1 // written on line as 123.1
};
```

I'd like to open this up for discussion, and if this is something we want to move forward with, we can add tests.

Addresses #87.