### PR TITLE
Return errors (such as ECONNREFUSED) when you're out of hosts

### DIFF
--- a/lib/InfluxRequest.js
+++ b/lib/InfluxRequest.js
@@ -50,6 +50,10 @@ InfluxRequest.prototype.addHost = function (hostname, port, protocol) {
   });
 };
 
+InfluxRequest.prototype.hostIsAvailable = function () {
+  return !!this.hostsAvailable[this.index];
+};
+
 InfluxRequest.prototype.getHost = function () {
 
   var host = this.hostsAvailable[this.index];
@@ -119,7 +123,7 @@ InfluxRequest.prototype._parseCallback = function (err, response, body, requestO
 
   if (err && -1 !== resubmitErrorCodes.indexOf(err.code)) {
     this.disableHost(requestOptions.host);
-    if (this.options.maxRetries >= requestOptions.retries) {
+    if (this.options.maxRetries >= requestOptions.retries && this.hostIsAvailable()) {
       return this._request(requestOptions, callback);
     }
   }

--- a/lib/InfluxRequest.js
+++ b/lib/InfluxRequest.js
@@ -51,8 +51,8 @@ InfluxRequest.prototype.addHost = function (hostname, port, protocol) {
 };
 
 InfluxRequest.prototype.hostIsAvailable = function () {
-  return !!this.hostsAvailable[this.index];
-};
+  return !!this.hostsAvailable[this.index]
+}
 
 InfluxRequest.prototype.getHost = function () {
 


### PR DESCRIPTION
If you make a request against a non-existent hostname, you get a nice error, with code ENOTFOUND.

But if you make a request against a server that does not have influxdb running, you don't get an ECONNREFUSED.   This is because a resubmit attempt hides the specific error, giving only 'No hosts available'.

Since some specific error codes are hidden, it makes it impossible to distinguish between, for example, ECONNREFUSED and ETIMEOUT

This is based of 3.4.0, since that's the version I'm using. 

