### PR TITLE
Adding missing quotes on CREATE CONTINUOUS QUERY

### DIFF
--- a/index.js
+++ b/index.js
@@ -369,7 +369,7 @@ InfluxDB.prototype.createContinuousQuery = function (queryName, queryString, dat
     databaseName = this.options.database
   }
 
-  var query = 'CREATE CONTINUOUS QUERY ' + queryName + ' ON ' + databaseName + ' BEGIN ' +
+  var query = 'CREATE CONTINUOUS QUERY ' + queryName + ' ON "' + databaseName + '" BEGIN ' +
     queryString +
     ' END'
   this.queryDB(query, callback)


### PR DESCRIPTION
This fixes creation of continuous queries with dashes (-) in the name