### PR TITLE
Return errors (such as ECONNREFUSED) when you're out of hosts (in master)

### DIFF
--- a/lib/InfluxRequest.js
+++ b/lib/InfluxRequest.js
@@ -47,6 +47,10 @@ InfluxRequest.prototype.addHost = function (hostname, port, protocol) {
   })
 }
 
+InfluxRequest.prototype.hostIsAvailable = function () {
+  return !!this.hostsAvailable[this.index];
+};
+
 InfluxRequest.prototype.getHost = function () {
   var host = this.hostsAvailable[this.index]
   ++this.index
@@ -111,7 +115,7 @@ InfluxRequest.prototype._request = function (options, callback) {
 InfluxRequest.prototype._parseCallback = function (err, response, body, requestOptions, callback) {
   if (err && resubmitErrorCodes.indexOf(err.code) !== -1) {
     this.disableHost(requestOptions.host)
-    if (this.options.maxRetries >= requestOptions.retries) {
+    if (this.options.maxRetries >= requestOptions.retries && this.hostIsAvailable()) {
       return this._request(requestOptions, callback)
     }
   }

--- a/lib/InfluxRequest.js
+++ b/lib/InfluxRequest.js
@@ -48,8 +48,8 @@ InfluxRequest.prototype.addHost = function (hostname, port, protocol) {
 }
 
 InfluxRequest.prototype.hostIsAvailable = function () {
-  return !!this.hostsAvailable[this.index];
-};
+  return !!this.hostsAvailable[this.index]
+}
 
 InfluxRequest.prototype.getHost = function () {
   var host = this.hostsAvailable[this.index]


### PR DESCRIPTION
This makes is parallel other error cases, like ENOTFOUND.
Before, it would return 'No hosts available' for all resubmittable errors instead of the actual error
Getting the proper error code makes it possible to distinguish between different errors, for example:
  ECONNREFUSED:  influxdb is not listening on this port
  vs.
  ETIMEOUT:  no response (perhaps due to a firewall)