### PR TITLE
Fix encoding failues on objects containing a 'length' key

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,23 +247,27 @@ InfluxDB.prototype.dropUser = function (username, callback) {
 }
 
 InfluxDB.prototype._createKeyValueString = function (object) {
-  return _.map(object, function (value, key) {
+  var output = []
+  _.forOwn(object, function (value, key) {
     if (typeof value === 'string') {
-      return key + '="' + value + '"'
+      output.push(key + '="' + value + '"')
     } else {
-      return key + '=' + value
+      output.push(key + '=' + value)
     }
-  }).join(',')
+  })
+  return output.join(',')
 }
 
 InfluxDB.prototype._createKeyTagString = function (object) {
-  return _.map(object, function (value, key) {
+  var output = []
+  _.forOwn(object, function (value, key) {
     if (typeof value === 'string') {
-      return key + '=' + value.replace(/ /g, '\\ ').replace(/,/g, '\\,')
+      output.push(key + '=' + value.replace(/ /g, '\\ ').replace(/,/g, '\\,'))
     } else {
-      return key + '=' + value
+      output.push(key + '=' + value)
     }
-  }).join(',')
+  })
+  return output.join(',')
 }
 
 InfluxDB.prototype._prepareValues = function (series) {

--- a/test.js
+++ b/test.js
@@ -313,6 +313,10 @@ describe('InfluxDB', function () {
     it('should write a point with a string as value into the database (using different method)', function (done) {
       dbClient.writePoint(info.series.strName, 'my second test string', {}, done)
     })
+
+    it('should write a point that has "length" in its keys', function (done) {
+      dbClient.writePoint(info.series.strName, {length: 3}, {length: '5'}, done)
+    })
   })
 
   describe('#writePoints', function () {


### PR DESCRIPTION
This adds a test case and fixes encoding failures when trying to write data that contains a "length" key or value. Prior to these fixes the added test case would fail with:

![](https://peet.io/i/16-04-69hl7W5VCwgTqBg0ggxoe7gUa.png)

Previously the \_.createKey*String was using `_.map` which, while it _worked_ over objects, was actually a lodash method to work on collections. Evidently the logic lodash used to decide whether something was a collection or an object was to see if it had a `length` key, so objects that did contain a length key were treated as arrays. This PR replaces it with `_.forOwn` to explicitly iterate over enumerable properties.