### PR TITLE
Support configuring the client using URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ You can either pass a single hostname or an array of hostnames. Node-influx uses
 the requests across all configured hosts. When a host is unreachable, node-influx tries to resubmit the request to another
 host and disables the failed host for 60 seconds (timeout value is configurable). If all servers fail to respond, node-influx raises an error.
 
+You can also pass an URL or an array of URLs:
+
+```js
+var influx = require('influx')
+
+var client = influx('http://dbuser:f4ncyp4ass@localhost:8060/my_database')
+// or
+client = influx({
+  hosts: ['http://127.0.0.1', 'https://127.0.0.2'],
+  username: 'dbuser',
+  password: 'f4ncyp4ass',
+  database: 'my_database'
+ })
+```
+
 
 ### Configuration options
 

--- a/test.js
+++ b/test.js
@@ -49,6 +49,37 @@ describe('InfluxDB', function () {
 
       assert(client instanceof influx.InfluxDB)
     })
+
+    describe('configured using URLs', function () {
+      it('should parse it when passed as `options`', function () {
+        var urlClient = influx(
+          'http://admin:fancierpassword@influx.foobar.com:1337/mydatabase'
+        )
+
+        assert.equal(urlClient.options.host, 'influx.foobar.com')
+        assert.equal(urlClient.options.port, 1337)
+        assert.equal(urlClient.options.username, 'admin')
+        assert.equal(urlClient.options.password, 'fancierpassword')
+        assert.equal(urlClient.options.database, 'mydatabase')
+      })
+
+      it('should parse them when passed in `hosts`', function () {
+        var urlClient = influx({
+          hosts: [
+            'http://127.0.0.1:1337',
+            'https://127.0.0.2:1338'
+          ]
+        })
+
+        var hostsParsed = urlClient.getHostsAvailable()
+        assert.equal(hostsParsed[0].name, '127.0.0.1')
+        assert.equal(hostsParsed[0].port, 1337)
+        assert.equal(hostsParsed[0].protocol, 'http:')
+        assert.equal(hostsParsed[1].name, '127.0.0.2')
+        assert.equal(hostsParsed[1].port, 1338)
+        assert.equal(hostsParsed[1].protocol, 'https:')
+      })
+    })
   })
 
   describe('#setRequestTimeout', function () {


### PR DESCRIPTION
This adds support for configuring the client like this:

```js
var client = influx('http://dbuser:f4ncyp4ass@localhost:8060/my_database')
```

I find URLs very convenient for configuring things which require the data this client does (for example, in command line tools, so that only one command line switch is needed). Other example of a module which supports URLs in a similar fashion is [`redis`](https://www.npmjs.com/package/redis).

I am not sure if this should stick with the `http(s):` protocol, however. If user tried sending a request to a URL like this, they would get a 404. A thought of `influxdb(s):` protocol crossed my mind.
