### PR TITLE
Support InfluxDb 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "4"
   - "0.12"
 env:
-  - INFLUX=0.9.6.1
+  - INFLUX=0.12.1-1
 before_script:
   - wget "http://s3.amazonaws.com/influxdb/influxdb_$(echo $INFLUX)_amd64.deb"
   - sudo dpkg -i "influxdb_$(echo $INFLUX)_amd64.deb"

--- a/index.js
+++ b/index.js
@@ -186,6 +186,9 @@ InfluxDB.prototype.getSeries = function (measurementName, callback) {
     if (err) {
       return callback(err, results)
     }
+    if (undefined === results[0].series) {
+      return callback(null, []);
+    }
     return callback(err, results[0].series[0].values.reduce(function (cur, next) {
       cur = cur.concat(next)
       return cur

--- a/index.js
+++ b/index.js
@@ -164,7 +164,10 @@ InfluxDB.prototype.getSeriesNames = function (measurementName, callback) {
     if (err) {
       return callback(err, results)
     }
-    return callback(err, _.map(results[0].series, function (series) {return series.name}))
+    return callback(err, results[0].series[0].values.reduce(function(cur, next) {
+      cur = cur.concat(next)
+      return cur
+    }, []))
   })
 
 }
@@ -183,7 +186,10 @@ InfluxDB.prototype.getSeries = function (measurementName, callback) {
     if (err) {
       return callback(err, results)
     }
-    return callback(err, results[0].series)
+    return callback(err, results[0].series[0].values.reduce(function(cur, next) {
+      cur = cur.concat(next)
+      return cur
+    }, []))
   })
 
 }

--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ InfluxDB.prototype.getSeriesNames = function (measurementName, callback) {
     if (err) {
       return callback(err, results)
     }
-    return callback(err, results[0].series[0].values.reduce(function(cur, next) {
+    return callback(err, results[0].series[0].values.reduce(function (cur, next) {
       cur = cur.concat(next)
       return cur
     }, []))
@@ -186,7 +186,7 @@ InfluxDB.prototype.getSeries = function (measurementName, callback) {
     if (err) {
       return callback(err, results)
     }
-    return callback(err, results[0].series[0].values.reduce(function(cur, next) {
+    return callback(err, results[0].series[0].values.reduce(function (cur, next) {
       cur = cur.concat(next)
       return cur
     }, []))

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "request": "2.x"
   },
   "devDependencies": {
+    "async": "^2.0.0-rc.3",
     "coveralls": "^2.11.1",
     "istanbul": "^0.3.2",
     "mocha": "2.2.x",

--- a/test.js
+++ b/test.js
@@ -232,6 +232,7 @@ describe('InfluxDB', function () {
   })
 
   describe('#grantAdminPrivileges', function () {
+    this.timeout(10000);
     it('should grant admin privileges without error', function (done) {
       client.grantAdminPrivileges(info.db.username, done)
     })
@@ -244,8 +245,19 @@ describe('InfluxDB', function () {
   })
 
   describe('#revokeAdminPrivileges', function () {
+    this.timeout(25000);
+    var testUser = {
+      username: 'revokeAdminPrivileges',
+      passowrd: 'password'
+    }
+    beforeEach((done) => {
+      client.createUser(testUser.username, testUser.password, true, done);
+    })
+    afterEach((done) => {
+      client.dropUser(testUser.username, done);
+    })
     it('should revoke admin privileges without error', function (done) {
-      client.revokeAdminPrivileges(info.db.username, done)
+      client.revokeAdminPrivileges(testUser.username, done)
     })
     it('should error when revoking admin privileges', function (done) {
       client.revokeAdminPrivileges('yourmum', function (err) {

--- a/test.js
+++ b/test.js
@@ -168,12 +168,13 @@ describe('InfluxDB', function () {
   })
 
   describe('#createUser', function () {
+    this.timeout(25000);
     it('should create a user without error', function (done) {
       client.createUser(info.db.username, info.db.password, true, done)
     })
     it('should error when creating an existing user', function (done) {
       client.createUser(info.db.username, info.db.password, function (err) {
-        assert(err instanceof Error)
+        assert.equal(err.message, 'user already exists')
         done()
       })
     })
@@ -255,12 +256,13 @@ describe('InfluxDB', function () {
   })
 
   describe('#dropUser', function () {
+    this.timeout(25000);
     it('should delete a user without error', function (done) {
       client.dropUser(info.db.username, done)
     })
-    it('should error when deleting an existing user', function (done) {
+    it('should error when deleting a non-existing user', function (done) {
       client.dropUser(info.db.username, function (err) {
-        assert.ifError(err)
+        assert.equal(err.message, 'user not found')
         done()
       })
     })

--- a/test.js
+++ b/test.js
@@ -1,10 +1,10 @@
-'use strict';
+'use strict'
 
 /* eslint-env mocha */
 var influx = require('./')
 var assert = require('assert')
-var ts = new Date().getTime();
-var async = require('async');
+var ts = new Date().getTime()
+var async = require('async')
 var client
 var dbClient
 var failClient
@@ -51,7 +51,7 @@ function writeFixtures(done) {
       dbClient.writePoint(info.series.strName, 'my second test string', {}, cb)
     },
   ], function() {
-    return done();
+    return done()
   })
 }
 before((done) => {
@@ -67,13 +67,13 @@ before((done) => {
   ], username: info.server.username, passwort: info.server.password, database: info.db.name})
 
   assert(client instanceof influx.InfluxDB)
-  return client.createDatabase(info.db.name, done);
+  return client.createDatabase(info.db.name, done)
 })
 after(function(done) {
   client.dropDatabase(info.db.name, function(err) {
-    return done();
-  });
-});
+    return done()
+  })
+})
 
 describe('InfluxDB', function () {
   describe('#InfluxDB', function () {
@@ -197,7 +197,7 @@ describe('InfluxDB', function () {
   })
 
   describe('#createUser', function () {
-    this.timeout(25000);
+    this.timeout(25000)
     it('should create a user without error', function (done) {
       client.createUser(info.db.username, info.db.password, true, done)
     })
@@ -261,7 +261,7 @@ describe('InfluxDB', function () {
   })
 
   describe('#grantAdminPrivileges', function () {
-    this.timeout(25000);
+    this.timeout(25000)
     it('should grant admin privileges without error', function (done) {
       client.grantAdminPrivileges(info.db.username, done)
     })
@@ -274,16 +274,16 @@ describe('InfluxDB', function () {
   })
 
   describe('#revokeAdminPrivileges', function () {
-    this.timeout(25000);
+    this.timeout(25000)
     var testUser = {
       username: 'revokeAdminPrivileges',
       passowrd: 'password'
     }
     beforeEach((done) => {
-      client.createUser(testUser.username, testUser.password, true, done);
+      client.createUser(testUser.username, testUser.password, true, done)
     })
     afterEach((done) => {
-      client.dropUser(testUser.username, done);
+      client.dropUser(testUser.username, done)
     })
     it('should revoke admin privileges without error', function (done) {
       client.revokeAdminPrivileges(testUser.username, done)
@@ -297,7 +297,7 @@ describe('InfluxDB', function () {
   })
 
   describe('#dropUser', function () {
-    this.timeout(25000);
+    this.timeout(25000)
     it('should delete a user without error', function (done) {
       client.dropUser(info.db.username, done)
     })
@@ -507,7 +507,7 @@ describe('InfluxDB', function () {
   describe('#getSeries', function () {
     before((done) => {
       client.createDatabase(info.db.name, () => {
-        return writeFixtures(done);
+        return writeFixtures(done)
       })
     })
     it('should return array of series', function (done) {
@@ -532,8 +532,8 @@ describe('InfluxDB', function () {
 
   describe('#getSeriesNames', function () {
     before((done) => {
-      writeFixtures(done);
-    });
+      writeFixtures(done)
+    })
     it('should return array of series names', function (done) {
       client.getSeriesNames(function (err, series) {
         if (err) return done(err)

--- a/test.js
+++ b/test.js
@@ -71,7 +71,7 @@ before((done) => {
 })
 after(function (done) {
   client.dropDatabase(info.db.name, function (err) {
-    if (err) { 
+    if (err) {
       // do nothing
     }
     return done()

--- a/test.js
+++ b/test.js
@@ -523,7 +523,7 @@ describe('InfluxDB', function () {
       client.getSeries(info.series.name, function (err, series) {
         if (err) return done(err)
         assert(series instanceof Array)
-        assert.equal(series.length, 1)
+        assert.equal(series.length, 3)
         done()
       })
     })
@@ -592,9 +592,9 @@ describe('InfluxDB', function () {
     it('should delete the database without error', function (done) {
       client.dropDatabase(info.db.name, done)
     })
-    it('should error if database didn\'t exist', function (done) {
+    it('should not error if database didn\'t exist', function (done) {
       client.dropDatabase(info.db.name, function (err) {
-        assert(err instanceof Error)
+        assert.ifError(err)
         done()
       })
     })

--- a/test.js
+++ b/test.js
@@ -505,6 +505,11 @@ describe('InfluxDB', function () {
   })
 
   describe('#getSeries', function () {
+    before((done) => {
+      client.createDatabase(info.db.name, () => {
+        return writeFixtures(done);
+      })
+    })
     it('should return array of series', function (done) {
       client.getSeries(function (err, series) {
         if (err) return done(err)
@@ -526,6 +531,9 @@ describe('InfluxDB', function () {
   })
 
   describe('#getSeriesNames', function () {
+    before((done) => {
+      writeFixtures(done);
+    });
     it('should return array of series names', function (done) {
       client.getSeriesNames(function (err, series) {
         if (err) return done(err)

--- a/test.js
+++ b/test.js
@@ -183,7 +183,9 @@ describe('InfluxDB', function () {
       client.getUsers(function (err, users) {
         assert.equal(err, null)
         assert(users instanceof Array)
-        assert.equal(users.length, 1)
+        assert.equal(users.filter(function(u) {
+          return u.user === 'johnsmith'
+        }).length, 1)
         done()
       })
     })

--- a/test.js
+++ b/test.js
@@ -259,7 +259,7 @@ describe('InfluxDB', function () {
     })
     it('should error when deleting an existing user', function (done) {
       client.dropUser(info.db.username, function (err) {
-        assert(err instanceof Error)
+        assert.ifError(err)
         done()
       })
     })

--- a/test.js
+++ b/test.js
@@ -30,10 +30,10 @@ var info = {
   }
 }
 
-function writeFixtures(done) {
+function writeFixtures (done) {
   async.series([
     (cb) => {
-      dbClient.writePoint(info.series.name, {value: 232, value2: 123}, { foo: 'bar', foobar: 'baz'}, cb)      
+      dbClient.writePoint(info.series.name, {value: 232, value2: 123}, { foo: 'bar', foobar: 'baz'}, cb)
     },
     (cb) => {
       dbClient.writePoint(info.series.name, 1, { foo: 'bar', foobar: 'baz'}, cb)
@@ -49,8 +49,8 @@ function writeFixtures(done) {
     },
     (cb) => {
       dbClient.writePoint(info.series.strName, 'my second test string', {}, cb)
-    },
-  ], function() {
+    }
+  ], function () {
     return done()
   })
 }
@@ -69,8 +69,11 @@ before((done) => {
   assert(client instanceof influx.InfluxDB)
   return client.createDatabase(info.db.name, done)
 })
-after(function(done) {
-  client.dropDatabase(info.db.name, function(err) {
+after(function (done) {
+  client.dropDatabase(info.db.name, function (err) {
+    if (err) { 
+      // do nothing
+    }
     return done()
   })
 })
@@ -214,7 +217,7 @@ describe('InfluxDB', function () {
       client.getUsers(function (err, users) {
         assert.equal(err, null)
         assert(users instanceof Array)
-        assert.equal(users.filter(function(u) {
+        assert.equal(users.filter(function (u) {
           return u.user === 'johnsmith'
         }).length, 1)
         done()

--- a/test.js
+++ b/test.js
@@ -192,7 +192,7 @@ describe('InfluxDB', function () {
       })
     })
 
-    it('should error when deleting an existing user', function (done) {
+    it('should bubble errors through', function (done) {
       failClient.getUsers(function (err) {
         assert(err instanceof Error)
         done()

--- a/test.js
+++ b/test.js
@@ -232,7 +232,7 @@ describe('InfluxDB', function () {
   })
 
   describe('#grantAdminPrivileges', function () {
-    this.timeout(10000);
+    this.timeout(25000);
     it('should grant admin privileges without error', function (done) {
       client.grantAdminPrivileges(info.db.username, done)
     })

--- a/test.js
+++ b/test.js
@@ -132,9 +132,9 @@ describe('InfluxDB', function () {
     it('should create a new database without error', function (done) {
       client.createDatabase(info.db.name, done)
     })
-    it('should throw an error if db already exists', function (done) {
+    it('should not throw an error if db already exists', function (done) {
       client.createDatabase(info.db.name, function (err) {
-        assert(err instanceof Error)
+        assert.equal(err, null)
         done()
       })
     })


### PR DESCRIPTION
Basically I refactored a little the test suite to make tests runnable independently.
Also the test db is created and deleted afetr every run. 
Few changes on library, to match some new behavior of the library.

I tested it locally with InfluxDb `0.12.1`, the only missing test is the `#query failover` that I don't understand completely. But happy to learn and fix also that!

Refs: #122 