### PR TITLE
Moved removal of point[0].time to createKeyValueString method

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,10 +248,8 @@ InfluxDB.prototype.dropUser = function (username, callback) {
 
 InfluxDB.prototype._createKeyValueString = function (object) {
   var output = []
-  
-  clone = _.clone(object)
+  var clone = _.clone(object)
   delete clone.time
-  
   _.forOwn(clone, function (value, key) {
     if (typeof value === 'string') {
       output.push(key + '="' + value + '"')

--- a/index.js
+++ b/index.js
@@ -249,9 +249,9 @@ InfluxDB.prototype.dropUser = function (username, callback) {
 InfluxDB.prototype._createKeyValueString = function (object) {
   var output = []
   _.forOwn(object, function (value, key) {
-    if (typeof value === 'string') {
+    if (typeof value === 'string' && key !== 'time') {
       output.push(key + '="' + value + '"')
-    } else {
+    } else if (key !== 'time') {
       output.push(key + '=' + value)
     }
   })
@@ -283,7 +283,6 @@ InfluxDB.prototype._prepareValues = function (series) {
         var timestamp = null
         if (points[0].time) {
           timestamp = points[0].time
-          delete (points[0].time)
         }
         line += ' ' + this._createKeyValueString(points[0])
         if (timestamp) {

--- a/index.js
+++ b/index.js
@@ -248,10 +248,14 @@ InfluxDB.prototype.dropUser = function (username, callback) {
 
 InfluxDB.prototype._createKeyValueString = function (object) {
   var output = []
-  _.forOwn(object, function (value, key) {
-    if (typeof value === 'string' && key !== 'time') {
+  
+  clone = _.clone(object)
+  delete clone.time
+  
+  _.forOwn(clone, function (value, key) {
+    if (typeof value === 'string') {
       output.push(key + '="' + value + '"')
-    } else if (key !== 'time') {
+    } else {
       output.push(key + '=' + value)
     }
   })

--- a/test.js
+++ b/test.js
@@ -378,7 +378,8 @@ describe('InfluxDB', function () {
       }
       var response = dbClient._prepareValues(data)
       var expected = 'series1,foobar=baz value=232 1234567787\nseries1,foobar=baz othervalue=212 1234567777\nseries1,foobar=baz andanothervalue=452 1234567747\nseries2,foobar=baz value=232 1234567787\nseries2,foobar=baz othervalue=212 1234567777\nseries2,foobar=baz andanothervalue=452 1234567747'
-      assert.equal(response, expected);
+      assert.equal(response, expected)
+      done()
     })
   })
 

--- a/test.js
+++ b/test.js
@@ -366,6 +366,20 @@ describe('InfluxDB', function () {
       }
       dbClient.writeSeries(data, done)
     })
+    it('should write multiple points to multiple time series, differing column names, specified timestamps', function (done) {
+      var points = [
+        [{value: 232, time: 1234567787}, { foobar: 'baz'}],
+        [{othervalue: 212, time: 1234567777}, { foobar: 'baz'}],
+        [{andanothervalue: 452, time:1234567747}, { foobar: 'baz'}]
+      ]
+      var data = {
+        series1: points,
+        series2: points
+      }
+      var response = dbClient._prepareValues(data)
+      var expected = 'series1,foobar=baz value=232 1234567787\nseries1,foobar=baz othervalue=212 1234567777\nseries1,foobar=baz andanothervalue=452 1234567747\nseries2,foobar=baz value=232 1234567787\nseries2,foobar=baz othervalue=212 1234567777\nseries2,foobar=baz andanothervalue=452 1234567747'
+      assert.equal(response, expected);
+    })
   })
 
   describe('#query', function () {

--- a/test.js
+++ b/test.js
@@ -370,7 +370,7 @@ describe('InfluxDB', function () {
       var points = [
         [{value: 232, time: 1234567787}, { foobar: 'baz'}],
         [{othervalue: 212, time: 1234567777}, { foobar: 'baz'}],
-        [{andanothervalue: 452, time:1234567747}, { foobar: 'baz'}]
+        [{andanothervalue: 452, time: 1234567747}, { foobar: 'baz'}]
       ]
       var data = {
         series1: points,


### PR DESCRIPTION
Had issues passing a series of points into the writeSeries function: subsequent points would have their time value stripped, and thus entered under the wrong timestamp.

It seems that during the `_.each` loop in `_prepareValues`, the `delete points[0].time` command got propagated to all points, which causes subsequent points to not have a `time` field in points[0], which then causes the method to write the current timestamp for the event, instead of the timestamp specified.