### PR TITLE
feat: Add constructor overload for #128 to TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,8 +4,22 @@ declare module "influx" {
 
     namespace influx {
         interface InfluxConstructor {
+            /**
+             * Connect to a single InfluxDB instance by specifying a set of connection options.
+             */
             (options: SingleHostOptions): Influx;
+            
+            /**
+             * Connect to an InfluxDB cluster by specifying a set of connection options.
+             */
             (options: ClusterOptions): Influx;
+            
+            /**
+             * Connect to an InfluxDB instance using a configuration URL.
+             * 
+             * Example: http://user:password@host:8086/database
+             */
+            (url: string): Influx;
         }
 
         type TimePrecision = "ns"|"us"|"ms"|"s"|"m"|"h"|"d"|"w"|"m"|"y";


### PR DESCRIPTION
Just a quick update to the TypeScript definition file to add support for #128 to it (as well as a couple extra doc comments).

In line with the contributing guidelines, I'll not merge this myself :+1:.