### PR TITLE
Add TypeScript Definition Tests

### DIFF
--- a/index-test.ts
+++ b/index-test.ts
@@ -1,0 +1,17 @@
+import * as influx from "./"
+
+var username = 'root'
+var password = 'root'
+var database = 'example_app_db'
+
+var client = influx({host: 'localhost', username: username, password: password, database: database})
+
+client.createDatabase('123', function (err) {
+  if (err) throw err
+  console.log('Database Created')
+})
+
+client.writePoint('response_times', { time: new Date(), value: Math.random() * 100 }, function (err) {
+  if (err) throw err
+  console.log('Points recorded')
+})

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,348 +1,356 @@
-declare module "influx" {
-    export = influx;
-    var influx: influx.InfluxConstructor;
+export = influx;
+declare var influx: influx.InfluxConstructor;
 
-    namespace influx {
-        interface InfluxConstructor {
-            /**
-             * Connect to a single InfluxDB instance by specifying a set of connection options.
-             */
-            (options: SingleHostOptions): Influx;
-            
-            /**
-             * Connect to an InfluxDB cluster by specifying a set of connection options.
-             */
-            (options: ClusterOptions): Influx;
-            
-            /**
-             * Connect to an InfluxDB instance using a configuration URL.
-             * 
-             * Example: http://user:password@host:8086/database
-             */
-            (url: string): Influx;
-        }
+declare namespace influx {
+    interface InfluxConstructor {
+        /**
+         * Connect to a single InfluxDB instance by specifying a set of connection options.
+         */
+        (options: SingleHostOptions): Influx;
 
-        type TimePrecision = "ns"|"us"|"ms"|"s"|"m"|"h"|"d"|"w"|"m"|"y";
+        /**
+         * Connect to an InfluxDB cluster by specifying a set of connection options.
+         */
+        (options: ClusterOptions): Influx;
 
-        interface Options {
-            /**
-             * database name
-             */
-            database: string;
-            /**
-             * username
-             */
-            username: string;
-            /**
-             * password
-             */
-            password: string;
+        /**
+         * Connect to an InfluxDB instance using a configuration URL.
+         *
+         * Example: http://user:password@host:8086/database
+         */
+        (url: string): Influx;
+    }
 
-            /**
-             * logging function for depreciated warnings, defaults to console.log
-             */
-            depreciatedLogging?: (format: string, ...args: any[]) => void;
-            /**
-             * number of ms node-influx will take a host out of the balancing after a request failed, default: 60000
-             */
-            failoverTimeout?: number;
-            /**
-             * number of ms to wait before a request times out. defaults to 'null' (waits until connection is closed).
-             * Use with caution!
-             */
-            requestTimeout?: number;
-            /**
-             * max number of retries until a request raises an error (e.g. 'no hosts available'), default : 2
-             */
-            maxRetries?: number;
-            /**
-             * Time precision, default : ms
-             */
-            timePrecision?: TimePrecision;
-        }
+    interface Influx {
+        /**
+         * Sets the default timeout for a request. When a request times out the host is removed from
+         * the list of available hosts and the request is resubmitted to the next configured host.
+         *
+         * The default value is null (will wait forever for a respose).
+         *
+         * Be careful with this setting. If the value is too low,
+         * slow queries might disable all configured hosts.
+         */
+        setRequestTimeout(value: number): void;
 
-        interface SingleHostOptions extends Options, Host {
+        /**
+         * Sets the failover timeout for a host. After a host has been removed from balancing,
+         * it will be re-enabled after 60 seconds (default).
+         *
+         * You can configure the timeout value using this function.
+         */
+        setFailoverTimeout(value: number): void;
 
-        }
+        /**
+         * Returns an array of available hosts.
+         */
+        getHostsAvailable(): Host[];
 
-        interface ClusterOptions extends Options {
-            /**
-             * Array of hosts for cluster configuration, e.g. [ {host: 'localhost', port : 8086},...]
-             * Port is optional
-             */
-            hosts: Host[];
-        }
+        /**
+         * Returns an array of disabled hosts. This can be useful to check whether a host is unresponsive or not.
+         */
+        getHostsDisabled(): Host[];
 
-        interface Host {
-            /**
-             * hostname, e.g. 'localhost'
-             */
-            host: string;
-            /**
-             * influxdb port, default: 8086
-             */
-            port?: number;
-            /**
-             * protocol, default: http
-             */
-            protocol?: "http"|"https"|"udp";
-        }
+        /**
+         * Creates a new database - requires cluster admin privileges
+         */
+        createDatabase(databaseName: string, callback: (err: Error) => void): void;
 
-        interface Influx {
-            /**
-             * Sets the default timeout for a request. When a request times out the host is removed from
-             * the list of available hosts and the request is resubmitted to the next configured host.
-             *
-             * The default value is null (will wait forever for a respose).
-             *
-             * Be careful with this setting. If the value is too low,
-             * slow queries might disable all configured hosts.
-             */
-            setRequestTimeout(value: number);
+        /**
+         * Returns array of database names - requires cluster admin privileges
+         */
+        getDatabaseNames(callback: (err: Error, names: string[]) => void): void;
 
-            /**
-             * Sets the failover timeout for a host. After a host has been removed from balancing,
-             * it will be re-enabled after 60 seconds (default).
-             *
-             * You can configure the timeout value using this function.
-             */
-            setFailoverTimeout(value: number);
+        /**
+         * Drops a database inluding all measurements/series - requires cluster admin privileges
+         */
+        dropDatabase(databaseName: string, callback: (err: Error) => void): void;
 
-            /**
-             * Returns an array of available hosts.
-             */
-            getHostsAvailable(): Host[];
+        /**
+         * Returns array of measurements - requires database admin privileges
+         */
+        getMeasurements(callback: (err: Error, measurements: Result) => void): void;
 
-            /**
-             * Returns an array of disabled hosts. This can be useful to check whether a host is unresponsive or not.
-             */
-            getHostsDisabled(): Host[];
+        /**
+         * Drops a measurement from a database - requires database admin privileges
+         */
+        dropMeasurement(measurementName: string, callback: (err: Error) => void): void;
 
-            /**
-             * Creates a new database - requires cluster admin privileges
-             */
-            createDatabase(databaseName: string, callback: (err: Error) => void);
+        /**
+         * Returns array of series names from given database - requires database admin privileges
+         */
+        getSeries(callback: (err: Error, series: Series[]) => void): void;
 
-            /**
-             * Returns array of database names - requires cluster admin privileges
-             */
-            getDatabaseNames(callback: (err: Error, names: string[]) => void);
+        /**
+         * Returns array of series names from given measurement - requires database admin privileges
+         */
+        getSeries(measurementName: string, callback: (err: Error, series: Series[]) => void): void;
 
-            /**
-             * Drops a database inluding all measurements/series - requires cluster admin privileges
-             */
-            dropDatabase(databaseName: string, callback: (err: Error) => void);
+        /**
+         * Returns array of series names from given database - requires database admin privileges
+         */
+        getSeriesNames(callback: (err: Error, seriesNames: string[]) => void): void;
 
-            /**
-             * Returns array of measurements - requires database admin privileges
-             */
-            getMeasurements(callback: (err: Error, measurements: Result) => void);
+        /**
+         * Returns array of series names from given measurement - requires database admin privileges
+         */
+        getSeriesNames(measurementName: string, callback: (err: Error, seriesNames: string[]) => void): void;
 
-            /**
-             * Drops a measurement from a database - requires database admin privileges
-             */
-            dropMeasurement(measurementName: string, callback: (err: Error) => void);
+        /**
+         * Drops a series from a database - requires database admin privileges
+         */
+        dropSeries(seriesId: string, callback: (err: Error) => void): void;
 
-            /**
-             * Returns array of series names from given database - requires database admin privileges
-             */
-            getSeries(callback: (err: Error, series: Series[]) => void);
+        /**
+         * Returns an array of users - requires cluster admin privileges
+         */
+        getUsers(callback: (err: Error, users: string[]) => void): void;
 
-            /**
-             * Returns array of series names from given measurement - requires database admin privileges
-             */
-            getSeries(measurementName: string, callback: (err: Error, series: Series[]) => void);
+        /**
+         * Creates a new database user - requires cluster admin privileges
+         */
+        createUser(username: string, password: string, isAdmin: boolean, callback: (err: Error) => void): void;
 
-            /**
-             * Returns array of series names from given database - requires database admin privileges
-             */
-            getSeriesNames(callback: (err: Error, seriesNames: string[]) => void);
+        /**
+         * Sets the users password - requires admin privileges
+         */
+        setPassword(username: string, password: string, callback: (err: Error) => void): void;
 
-            /**
-             * Returns array of series names from given measurement - requires database admin privileges
-             */
-            getSeriesNames(measurementName: string, callback: (err: Error, seriesNames: string[]) => void);
+        /**
+         * Grants privilege for the given user - requires admin privileges
+         */
+        grantPrivilege(privilege: string, databaseName: string, username: string, callback: (err: Error) => void): void;
 
-            /**
-             * Drops a series from a database - requires database admin privileges
-             */
-            dropSeries(seriesId: string, callback: (err: Error) => void);
+        /**
+         * Revokes privilege for the given user - requires admin privileges
+         */
+        revokePrivilege(privilege: string, databaseName: string, username: string, callback: (err: Error) => void): void;
 
-            /**
-             * Returns an array of users - requires cluster admin privileges
-             */
-            getUsers(callback: (err: Error, users: string[]) => void);
+        /**
+         * Grants admin privileges for the given user - requires admin privileges
+         */
+        grantAdminPrivileges(username: string, callback: (err: Error) => void): void;
 
-            /**
-             * Creates a new database user - requires cluster admin privileges
-             */
-            createUser(username: string, password: string, isAdmin: boolean, callback: (err: Error) => void);
+        /**
+         * Revokes all admin privileges for the given user - requires admin privileges
+         */
+        revokeAdminPrivileges(username: string, callback: (err: Error) => void): void;
 
-            /**
-             * Sets the users password - requires admin privileges
-             */
-            setPassword(username: string, password: string, callback: (err: Error) => void);
+        /**
+         * Drops the given user - requires admin privileges
+         */
+        dropUser(username: string, callback: (err: Error) => void): void;
 
-            /**
-             * Grants privilege for the given user - requires admin privileges
-             */
-            grantPrivilege(privilege: string, databaseName: string, username: string, callback: (err: Error) => void);
+        /**
+         * Writes a point to a series - requires database user privileges
+         */
+        writePoint(seriesName: string, value: PointValue, callback: (err: Error) => void): void;
 
-            /**
-             * Revokes privilege for the given user - requires admin privileges
-             */
-            revokePrivilege(privilege: string, databaseName: string, username: string, callback: (err: Error) => void);
+        /**
+         * Writes a point to a series - requires database user privileges
+         */
+        writePoint(seriesName: string, value: PointValue, tags: PointTags, callback: (err: Error) => void): void;
 
-            /**
-             * Grants admin privileges for the given user - requires admin privileges
-             */
-            grantAdminPrivileges(username: string, callback: (err: Error) => void);
+        /**
+         * Writes a point to a series - requires database user privileges
+         */
+        writePoint(seriesName: string, value: PointValue, tags: PointTags, options: WriteOptions, callback: (err: Error) => void): void;
 
-            /**
-             * Revokes all admin privileges for the given user - requires admin privileges
-             */
-            revokeAdminPrivileges(username: string, callback: (err: Error) => void);
+        /**
+         * Writes a point to a series - requires database user privileges
+         */
+        writePoint(seriesName: string, values: PointValues, callback: (err: Error) => void): void;
+        
+        /**
+         * Writes a point to a series - requires database user privileges
+         */
+        writePoint(seriesName: string, values: PointValues, tags: PointTags, callback: (err: Error) => void): void;
 
-            /**
-             * Drops the given user - requires admin privileges
-             */
-            dropUser(username: string, callback: (err: Error) => void);
+        /**
+         * Writes a point to a series - requires database user privileges
+         */
+        writePoint(seriesName: string, values: PointValues, tags: PointTags, options: WriteOptions, callback: (err: Error) => void): void;
 
-            /**
-             * Writes a point to a series - requires database user privileges
-             */
-            writePoint(seriesName: string, value: PointValue, tags: PointTags, callback: (err: Error) => void);
+        /**
+         * Writes multiple points to a series - requires database user privileges
+         */
+        writePoints(seriesName: string, points: PointsArray[], callback: (err: Error) => void): void;
 
-            /**
-             * Writes a point to a series - requires database user privileges
-             */
-            writePoint(seriesName: string, value: PointValue, tags: PointTags, options: WriteOptions, callback: (err: Error) => void);
+        /**
+         * Writes multiple points to a series - requires database user privileges
+         */
+        writePoints(seriesName: string, points: PointsArray[], options: WriteOptions, callback: (err: Error) => void): void;
 
-            /**
-             * Writes a point to a series - requires database user privileges
-             */
-            writePoint(seriesName: string, values: PointValues, tags: PointTags, callback: (err: Error) => void);
+        /**
+         * Writes multiple point to multiple series - requires database user privileges
+         */
+        writeSeries(series: { [name: string]: PointsArray[]; }, callback: (err: Error) => void): void;
 
-            /**
-             * Writes a point to a series - requires database user privileges
-             */
-            writePoint(seriesName: string, values: PointValues, tags: PointTags, options: WriteOptions, callback: (err: Error) => void);
+        /**
+         * Writes multiple point to multiple series - requires database user privileges
+         */
+        writeSeries(series: { [name: string]: PointsArray[]; }, options: WriteOptions, callback: (err: Error) => void): void;
 
-            /**
-             * Writes multiple points to a series - requires database user privileges
-             */
-            writePoints(seriesName: string, points: PointsArray[], callback: (err: Error) => void);
+        /**
+         * Queries the database and returns an array of parsed responses. - requires database user privileges.
+         */
+        query(query: string, callback: (err: Error, results: { [tag: string]: PointValue|Date; }[]) => void): void;
 
-            /**
-             * Writes multiple points to a series - requires database user privileges
-             */
-            writePoints(seriesName: string, points: PointsArray[], options: WriteOptions, callback: (err: Error) => void);
+        /**
+         * Queries the database and returns an array of parsed responses. - requires database user privileges.
+         */
+        query(databaseName: string, query: string, callback: (err: Error, results: { [tag: string]: PointValue|Date; }[]) => void): void;
 
-            /**
-             * Writes multiple point to multiple series - requires database user privileges
-             */
-            writeSeries(series: { [name: string]: PointsArray[]; }, callback: (err: Error) => void);
+        /**
+         * Queries the database and returns the raw response from InfluxDB. - requires database user privileges.
+         */
+        queryRaw(query: string, callback: (err: Error, results: Result) => void): void;
 
-            /**
-             * Writes multiple point to multiple series - requires database user privileges
-             */
-            writeSeries(series: { [name: string]: PointsArray[]; }, options: WriteOptions, callback: (err: Error) => void);
+        /**
+         * Queries the database and returns the raw response from InfluxDB. - requires database user privileges.
+         */
+        queryRaw(databaseName: string, query: string, callback: (err: Error, results: Result) => void): void;
 
-            /**
-             * Queries the database and returns an array of parsed responses. - requires database user privileges.
-             */
-            query(query: string, callback: (err: Error, results: { [tag: string]: PointValue|Date; }[]) => void);
+        /**
+         * Creates a continuous query - requires admin privileges
+         */
+        createContinuousQuery(queryName: string, query: string, callback: (err: Error) => void): void;
 
-            /**
-             * Queries the database and returns an array of parsed responses. - requires database user privileges.
-             */
-            query(databaseName: string, query: string, callback: (err: Error, results: { [tag: string]: PointValue|Date; }[]) => void);
+        /**
+         * Creates a continuous query - requires admin privileges
+         */
+        createContinuousQuery(queryName: string, query: string, databaseName: string, callback: (err: Error) => void): void;
 
-            /**
-             * Queries the database and returns the raw response from InfluxDB. - requires database user privileges.
-             */
-            queryRaw(query: string, callback: (err: Error, results: Result) => void);
+        /**
+         * Fetches all continuous queries from a database - requires database admin privileges
+         */
+        getContinuousQueries(callback: (err: Error, queries: string[]) => void): void;
 
-            /**
-             * Queries the database and returns the raw response from InfluxDB. - requires database user privileges.
-             */
-            queryRaw(databaseName: string, query: string, callback: (err: Error, results: Result) => void);
+        /**
+         * Drops a continuous query from a database - requires database admin privileges
+         */
+        dropContinuousQuery(queryName: string, callback: (err: Error) => void): void;
 
-            /**
-             * Creates a continuous query - requires admin privileges
-             */
-            createContinuousQuery(queryName: string, query: string, callback: (err: Error) => void);
+        /**
+         * Drops a continuous query from a database - requires database admin privileges
+         */
+        dropContinuousQuery(queryName: string, databaseName: string, callback: (err: Error) => void): void;
 
-            /**
-             * Creates a continuous query - requires admin privileges
-             */
-            createContinuousQuery(queryName: string, query: string, databaseName: string, callback: (err: Error) => void);
+        /**
+         * Fetches all retention policies from a database.
+         */
+        getRetentionPolicies(databaseName: string, callback: (err: Error, policies: string[]) => void): void;
 
-            /**
-             * Fetches all continuous queries from a database - requires database admin privileges
-             */
-            getContinuousQueries(callback: (err: Error, queries: string[]) => void);
+        /**
+         * Creates a new retention policy - requires admin privileges.
+         */
+        createRetentionPolicy(policyName: string, databaseName: string, duration: string, replication: number, isDefault: boolean, callback: (err: Error) => void): void;
 
-            /**
-             * Drops a continuous query from a database - requires database admin privileges
-             */
-            dropContinuousQuery(queryName: string, callback: (err: Error) => void);
+        /**
+         * Alters an existing retention policy - requires admin privileges.
+         */
+        alterRetentionPolicy(policyName: string, databaseName: string, duration: string, replication: number, isDefault: boolean, callback: (err: Error) => void): void;
+    }
 
-            /**
-             * Drops a continuous query from a database - requires database admin privileges
-             */
-            dropContinuousQuery(queryName: string, databaseName: string, callback: (err: Error) => void);
+    type TimePrecision = "ns"|"us"|"ms"|"s"|"m"|"h"|"d"|"w"|"m"|"y";
 
-            /**
-             * Fetches all retention policies from a database.
-             */
-            getRetentionPolicies(databaseName: string, callback: (err: Error, policies: string[]) => void);
+    interface Options {
+        /**
+         * database name
+         */
+        database: string;
+        /**
+         * username
+         */
+        username: string;
+        /**
+         * password
+         */
+        password: string;
 
-            /**
-             * Creates a new retention policy - requires admin privileges.
-             */
-            createRetentionPolicy(policyName: string, databaseName: string, duration: string, replication: number, isDefault: boolean, callback: (err: Error) => void);
+        /**
+         * logging function for depreciated warnings, defaults to console.log
+         */
+        depreciatedLogging?: (format: string, ...args: any[]) => void;
+        /**
+         * number of ms node-influx will take a host out of the balancing after a request failed, default: 60000
+         */
+        failoverTimeout?: number;
+        /**
+         * number of ms to wait before a request times out. defaults to 'null' (waits until connection is closed).
+         * Use with caution!
+         */
+        requestTimeout?: number;
+        /**
+         * max number of retries until a request raises an error (e.g. 'no hosts available'), default : 2
+         */
+        maxRetries?: number;
+        /**
+         * Time precision, default : ms
+         */
+        timePrecision?: TimePrecision;
+    }
 
-            /**
-             * Alters an existing retention policy - requires admin privileges.
-             */
-            alterRetentionPolicy(policyName: string, databaseName: string, duration: string, replication: number, isDefault: boolean, callback: (err: Error) => void);
-        }
+    interface SingleHostOptions extends Options, Host {
 
-        type PointValue = string|number;
+    }
 
-        interface PointValues {
-            time?: Date;
-            [name: string]: string|number|Date;
-        }
+    interface ClusterOptions extends Options {
+        /**
+         * Array of hosts for cluster configuration, e.g. [ {host: 'localhost', port : 8086},...]
+         * Port is optional
+         */
+        hosts: Host[];
+    }
 
-        type PointsArray = {
-            0: PointValue | PointValues;
-            1: PointTags
-        }
+    interface Host {
+        /**
+         * hostname, e.g. 'localhost'
+         */
+        host: string;
+        /**
+         * influxdb port, default: 8086
+         */
+        port?: number;
+        /**
+         * protocol, default: http
+         */
+        protocol?: "http"|"https"|"udp";
+    }
 
-        interface PointTags {
-            [tag: string]: any;
-        }
+    type PointValue = string|number;
 
-        interface WriteOptions {
-            precision: TimePrecision;
-        }
+    interface PointValues {
+        time?: Date;
+        [name: string]: string|number|Date;
+    }
 
-        interface Result {
-            series: Series[];
-            messages?: Message[];
-        }
+    type PointsArray = {
+        0: PointValue | PointValues;
+        1: PointTags
+    }
 
-        interface Series {
-            name: string;
-            columns: string[];
-            values: any[][];
-        }
+    interface PointTags {
+        [tag: string]: any;
+    }
 
-        interface Message {
-            level: string;
-            text: string;
-        }
+    interface WriteOptions {
+        precision: TimePrecision;
+    }
+
+    interface Result {
+        series: Series[];
+        messages?: Message[];
+    }
+
+    interface Series {
+        name: string;
+        columns: string[];
+        values: any[][];
+    }
+
+    interface Message {
+        level: string;
+        text: string;
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "lint": "standard",
     "test": "./node_modules/.bin/mocha -R spec",
-    "travis-test": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -R spec && npm run lint"
+    "tsd-test": "tsc --noImplicitAny --noEmit index-test.ts",
+    "travis-test": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -R spec && npm run lint && npm run tsd-test"
   },
   "repository": {
     "type": "git",
@@ -33,6 +34,7 @@
     "coveralls": "^2.11.1",
     "istanbul": "^0.3.2",
     "mocha": "2.2.x",
-    "standard": "4.5.x"
+    "standard": "4.5.x",
+    "typescript": "1.8.10"
   }
 }


### PR DESCRIPTION
This PR adds some small tests to help ensure we ship a valid definition file, primarily around compiling it and a very basic usecase (taken from the examples folder).

I've also rewritten the definition file to better support the `node` module resolution mode in TypeScript - it was previously targetting what is known as "ambient" or "global" inclusion, something which is being phased out as the compiler becomes more capable of resolving the correct definitions for various modules.