### PR TITLE
fix: Don't duplicate options when calling writeSeries

### DIFF
--- a/index.js
+++ b/index.js
@@ -365,7 +365,7 @@ InfluxDB.prototype.writePoint = function (seriesName, values, tags, options, cal
 InfluxDB.prototype.writePoints = function (seriesName, points, options, callback) {
   var data = {}
   data[seriesName] = points
-  this.writeSeries(data, options, options, callback)
+  this.writeSeries(data, options, callback)
 }
 
 InfluxDB.prototype.query = function (databaseName, query, callback) {


### PR DESCRIPTION
This resolves an issue when specifying options and calling `writePoints`
(or, by extension, `writePoint`) which would result in an exception
being thrown.

The exception itself is as follows:

```
Uncaught TypeError: callback is not a function
      at $PROJECT\node_modules\influx\index.js:102:14
      at InfluxRequest._parseCallback ($PROJECT\node_modules\influx\lib\InfluxRequest.js:122:10)
      at Request._callback ($PROJECT\node_modules\influx\lib\InfluxRequest.js:111:10)
      at Request.self.callback ($PROJECT\node_modules\request\request.js:200:22)
      at Request.<anonymous> ($PROJECT\node_modules\request\request.js:1067:10)
      at IncomingMessage.<anonymous> ($PROJECT\node_modules\request\request.js:988:12)
      at endReadableNT (_stream_readable.js:926:12)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```