### PR TITLE
Refactor tests to eliminate inter-test dependencies

### DIFF
--- a/test.js
+++ b/test.js
@@ -27,6 +27,11 @@ describe('InfluxDB', function () {
     }
   }
 
+  beforeEach(function() {
+    client = influx({host: info.server.host, port: info.server.port, username: info.server.username, password: info.server.password, database: info.db.name, retentionPolicy: info.db.retentionPolicy})
+    assert(client instanceof influx.InfluxDB)
+  })
+
   describe('#InfluxDB', function () {
     it('should exist as a function (class)', function () {
       assert(typeof influx.InfluxDB === 'function')
@@ -35,11 +40,8 @@ describe('InfluxDB', function () {
 
   describe('create client', function () {
     it('should create an instance without error', function () {
-      client = influx({host: info.server.host, port: info.server.port, username: info.server.username, password: info.server.password, database: info.db.name, retentionPolicy: info.db.retentionPolicy})
       dbClient = influx({host: info.server.host, port: info.server.port, username: info.server.username, password: info.server.password, database: info.db.name})
       failClient = influx({host: info.server.host, port: 6543, username: info.server.username, password: info.server.password, database: info.db.name})
-
-      assert(client instanceof influx.InfluxDB)
     })
 
     describe('configured using URLs', function () {

--- a/test.js
+++ b/test.js
@@ -273,13 +273,19 @@ describe('InfluxDB', function () {
   })
 
   describe('#dropDatabase', function () {
-    this.timeout(25000)
+    beforeEach(function (done) {
+      client.createDatabase(info.db.name, done)
+    })
     it('should delete the database without error', function (done) {
       client.dropDatabase(info.db.name, done)
     })
-    it('should not error if database didn\'t exist', function (done) {
+    it('should error if database didn\'t exist', function (done) {
       client.dropDatabase(info.db.name, function (err) {
-        done(err)
+        if (err) return done(err)
+        client.dropDatabase(info.db.name, function (err) {
+          assert(err instanceof Error)
+          done()
+        })
       })
     })
   })

--- a/test.js
+++ b/test.js
@@ -267,10 +267,8 @@ describe('InfluxDB', function () {
     it('should create a new database without error', function (done) {
       client.createDatabase(info.db.name, done)
     })
-    it('should not throw an error if db already exists', function (done) {
-      client.createDatabase(info.db.name, function (err) {
-        done(err)
-      })
+    afterEach(function (done) {
+      client.dropDatabase(info.db.name, done)
     })
   })
 
@@ -293,6 +291,15 @@ describe('InfluxDB', function () {
 
     afterEach(function (done) {
       client.dropDatabase(info.db.name, done)
+    })
+
+    describe('#duplicateDatabase', function () {
+      it('should report an error if db already exists', function (done) {
+        client.createDatabase(info.db.name, function (err) {
+          assert(err instanceof Error)
+          done()
+        })
+      })
     })
 
     describe('#getDatabaseNames', function () {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,21 @@
 /* eslint-env mocha */
 var influx = require('./')
 var assert = require('assert')
+var request = require('request')
+
+before(function (done) {
+  // Before doing anything validate that InfluxDB is a recent version and running
+  request('http://localhost:8086/ping', function (err, response, body) {
+    if (err) return done(err)
+    var version = response.headers['x-influxdb-version']
+    var major = version.split('.')[0]
+    var minor = version.split('.')[1]
+
+    assert.equal(major, 0)
+    assert(minor >= 13)
+    done()
+  })
+})
 
 describe('InfluxDB', function () {
   var client

--- a/test.js
+++ b/test.js
@@ -76,47 +76,51 @@ describe('InfluxDB', function () {
     })
   })
 
-  describe('#url', function () {
-    it('should build a properly formatted url', function () {
-      var url = client.url('query', { db: info.db.name, rp: info.db.retentionPolicy, precision: info.server.timePrecision })
-      assert.equal(url, /* 'http://'+info.server.host+':8086/' + */ 'query?u=' + info.server.username + '&p=' + info.server.password + '&db=' + info.db.name + '&rp=' + info.db.retentionPolicy + '&precision=' + info.server.timePrecision)
+  describe('#noNetwork', function() {
+    // Tests for library internals, do not send or recieve any data
+
+    describe('#url', function () {
+      it('should build a properly formatted url', function () {
+        var url = client.url('query', { db: info.db.name, rp: info.db.retentionPolicy, precision: info.server.timePrecision })
+        assert.equal(url, /* 'http://'+info.server.host+':8086/' + */ 'query?u=' + info.server.username + '&p=' + info.server.password + '&db=' + info.db.name + '&rp=' + info.db.retentionPolicy + '&precision=' + info.server.timePrecision)
+      })
+
+      it('should build a properly formatted url', function () {
+        var url = client.url('query')
+        assert.equal(url, /* 'http://'+info.server.host+':8086/' + */ 'query?u=' + info.server.username + '&p=' + info.server.password + '&precision=' + info.server.timePrecision + '&db=' + info.db.name + '&rp=' + info.db.retentionPolicy)
+      })
     })
 
-    it('should build a properly formatted url', function () {
-      var url = client.url('query')
-      assert.equal(url, /* 'http://'+info.server.host+':8086/' + */ 'query?u=' + info.server.username + '&p=' + info.server.password + '&precision=' + info.server.timePrecision + '&db=' + info.db.name + '&rp=' + info.db.retentionPolicy)
+    describe('#_createKeyTagString', function () {
+      it('should build a properly formatted string', function () {
+        var str = client._createKeyTagString({tag_1: 'value', tag2: 'value value', tag3: 'value,value'})
+        assert.equal(str, 'tag_1=value,tag2=value\\ value,tag3=value\\,value')
+      })
     })
-  })
 
-  describe('#_createKeyTagString', function () {
-    it('should build a properly formatted string', function () {
-      var str = client._createKeyTagString({tag_1: 'value', tag2: 'value value', tag3: 'value,value'})
-      assert.equal(str, 'tag_1=value,tag2=value\\ value,tag3=value\\,value')
+    describe('#_createKeyValueString', function () {
+      it('should build a properly formatted string', function () {
+        var str = client._createKeyValueString({a: 1, b: 2})
+        assert.equal(str, 'a=1,b=2')
+      })
     })
-  })
 
-  describe('#_createKeyValueString', function () {
-    it('should build a properly formatted string', function () {
-      var str = client._createKeyValueString({a: 1, b: 2})
-      assert.equal(str, 'a=1,b=2')
-    })
-  })
-
-  describe('parseResult()', function () {
-    it('should build a properly formatted response', function (done) {
-      client._parseResults([{'series': [{'name': 'myseries2', 'tags': {'mytag': 'foobarfoo'}, 'columns': ['time', 'value'], 'values': [['2015-06-27T06:25:54.411900884Z', 55]]}, {'name': 'myseries2', 'tags': {'mytag': 'foobarfoo2'}, 'columns': ['time', 'value'], 'values': [['2015-06-27T06:25:54.411900884Z', 29]]}]}],
-        function (err, results) {
-          if (err) return done(err)
-          assert.deepEqual(results,
-            [ [ { time: '2015-06-27T06:25:54.411900884Z',
-              value: 55,
-            mytag: 'foobarfoo' },
-              { time: '2015-06-27T06:25:54.411900884Z',
-                value: 29,
-              mytag: 'foobarfoo2' } ] ]
-          )
-          done()
-        })
+    describe('parseResult()', function () {
+      it('should build a properly formatted response', function (done) {
+        client._parseResults([{'series': [{'name': 'myseries2', 'tags': {'mytag': 'foobarfoo'}, 'columns': ['time', 'value'], 'values': [['2015-06-27T06:25:54.411900884Z', 55]]}, {'name': 'myseries2', 'tags': {'mytag': 'foobarfoo2'}, 'columns': ['time', 'value'], 'values': [['2015-06-27T06:25:54.411900884Z', 29]]}]}],
+          function (err, results) {
+            if (err) return done(err)
+            assert.deepEqual(results,
+              [ [ { time: '2015-06-27T06:25:54.411900884Z',
+                value: 55,
+              mytag: 'foobarfoo' },
+                { time: '2015-06-27T06:25:54.411900884Z',
+                  value: 29,
+                mytag: 'foobarfoo2' } ] ]
+            )
+            done()
+          })
+      })
     })
   })
 

--- a/test.js
+++ b/test.js
@@ -294,12 +294,11 @@ describe('InfluxDB', function () {
     it('should delete the database without error', function (done) {
       client.dropDatabase(info.db.name, done)
     })
-    it('should error if database didn\'t exist', function (done) {
+    it('should not error if database didn\'t exist', function (done) {
       client.dropDatabase(info.db.name, function (err) {
         if (err) return done(err)
         client.dropDatabase(info.db.name, function (err) {
-          assert(err instanceof Error)
-          done()
+          done(err)
         })
       })
     })
@@ -315,10 +314,9 @@ describe('InfluxDB', function () {
     })
 
     describe('#duplicateDatabase', function () {
-      it('should report an error if db already exists', function (done) {
+      it('should not report an error if db already exists', function (done) {
         client.createDatabase(info.db.name, function (err) {
-          assert(err instanceof Error)
-          done()
+          done(err)
         })
       })
     })
@@ -506,8 +504,14 @@ describe('InfluxDB', function () {
         it('should return array of series', function (done) {
           client.getSeries(function (err, series) {
             if (err) return done(err)
-            assert(series[0].values instanceof Array)
-            assert.equal(series[0].values.length, 2)
+            var expected = [ {
+              columns: [ 'key' ],
+              values: [
+                [ 'number_test,field1=f1' ],
+                [ 'number_test,field1=f1,field2=f2' ],
+                [ 'string_test' ]
+              ] } ]
+            assert.deepEqual(series, expected)
             done()
           })
         })

--- a/test.js
+++ b/test.js
@@ -22,14 +22,22 @@ describe('InfluxDB', function () {
       retentionPolicy: 'testrp'
     },
     series: {
-      name: 'response_time',
+      numName: 'number_test',
       strName: 'string_test'
     }
   }
 
-  beforeEach(function() {
+  beforeEach(function (done) {
     client = influx({host: info.server.host, port: info.server.port, username: info.server.username, password: info.server.password, database: info.db.name, retentionPolicy: info.db.retentionPolicy})
     assert(client instanceof influx.InfluxDB)
+
+    failClient = influx({host: info.server.host, port: 6543, username: info.server.username, password: info.server.password, database: info.db.name})
+    assert(failClient instanceof influx.InfluxDB)
+
+    dbClient = influx({host: info.server.host, port: info.server.port, username: info.server.username, password: info.server.password, database: info.db.name})
+    assert(dbClient instanceof influx.InfluxDB)
+
+    done()
   })
 
   describe('#InfluxDB', function () {
@@ -39,11 +47,6 @@ describe('InfluxDB', function () {
   })
 
   describe('create client', function () {
-    it('should create an instance without error', function () {
-      dbClient = influx({host: info.server.host, port: info.server.port, username: info.server.username, password: info.server.password, database: info.db.name})
-      failClient = influx({host: info.server.host, port: 6543, username: info.server.username, password: info.server.password, database: info.db.name})
-    })
-
     describe('configured using URLs', function () {
       it('should parse it when passed as `options`', function () {
         var urlClient = influx(
@@ -76,7 +79,7 @@ describe('InfluxDB', function () {
     })
   })
 
-  describe('#noNetwork', function() {
+  describe('#noNetwork', function () {
     // Tests for library internals, do not send or recieve any data
 
     describe('#url', function () {
@@ -142,6 +145,124 @@ describe('InfluxDB', function () {
     })
   })
 
+  describe('#disabledHosts', function () {
+    it('should return failed host', function (done) {
+      // Issue any request so that library disables a host
+      failClient.getUsers(function () {
+        var hosts = failClient.getHostsDisabled()
+        assert.equal(hosts.length, 1)
+        assert.equal(hosts[0].name, info.server.host)
+        done()
+      })
+    })
+  })
+
+  describe('#users', function () {
+    describe('#createUser', function () {
+      it('should create a user without error', function (done) {
+        client.createUser(info.db.username, info.db.password, true, done)
+      })
+      it('should error when creating an existing user', function (done) {
+        client.createUser(info.db.username, info.db.password, function (err) {
+          assert(err instanceof Error)
+          done()
+        })
+      })
+      after(function (done) {
+        client.dropUser(info.db.username, done)
+      })
+    })
+
+    describe('#dropUser', function () {
+      before(function (done) {
+        client.createUser(info.db.username, info.db.password, true, done)
+      })
+      it('should delete a user without error', function (done) {
+        client.dropUser(info.db.username, done)
+      })
+      it('should error when deleting a user that does not exist', function (done) {
+        client.dropUser(info.db.username, function (err) {
+          assert(err instanceof Error)
+          done()
+        })
+      })
+    })
+
+    describe('#withExistingUser', function () {
+      beforeEach(function (done) {
+        client.createUser(info.db.username, info.db.password, true, done)
+      })
+      afterEach(function (done) {
+        client.dropUser(info.db.username, done)
+      })
+
+      describe('#getUsers', function () {
+        it('should get an array of database users', function (done) {
+          client.getUsers(function (err, users) {
+            assert.equal(err, null)
+            assert(users instanceof Array)
+            assert.equal(users.length, 1)
+            done()
+          })
+        })
+        it('should error with failClient', function (done) {
+          failClient.getUsers(function (err) {
+            assert(err instanceof Error)
+            done()
+          })
+        })
+      })
+
+      describe('#setPassword', function () {
+        it('should update user password without error', function (done) {
+          client.setPassword(info.db.username, info.db.password, done)
+        })
+      })
+
+      describe('#grantAndRevokePrivileges', function () {
+        it('should grant user privileges without error', function (done) {
+          client.grantPrivilege('READ', info.db.name, info.db.username, done)
+        })
+        it('should error when granting user invalid privilege', function (done) {
+          client.grantPrivilege('BEER', info.db.name, info.db.username, function (err) {
+            assert(err instanceof Error)
+            done()
+          })
+        })
+        it('should revoke user privileges without error', function (done) {
+          client.revokePrivilege('READ', info.db.name, info.db.username, done)
+        })
+        it('should error when revoking invalid privilege', function (done) {
+          client.revokePrivilege('BEER', info.db.name, info.db.username, function (err) {
+            assert(err instanceof Error)
+            done()
+          })
+        })
+      })
+
+      describe('#grantAndRevokeAdminPrivileges', function () {
+        it('should grant admin privileges without error', function (done) {
+          client.grantAdminPrivileges(info.db.username, done)
+        })
+        it('should error when granting invalid privilege', function (done) {
+          client.grantAdminPrivileges('invalidPriv', function (err) {
+            assert(err instanceof Error)
+            done()
+          })
+        })
+        it('should revoke admin privileges without error', function (done) {
+          client.revokeAdminPrivileges(info.db.username, done)
+        })
+        it('should error when revoking invalid privilege', function (done) {
+          client.revokeAdminPrivileges('invalidPriv', function (err) {
+            assert(err instanceof Error)
+            done()
+          })
+        })
+      })
+    })
+  })
+
   describe('#createDatabase', function () {
     it('should create a new database without error', function (done) {
       client.createDatabase(info.db.name, done)
@@ -149,392 +270,6 @@ describe('InfluxDB', function () {
     it('should not throw an error if db already exists', function (done) {
       client.createDatabase(info.db.name, function (err) {
         done(err)
-      })
-    })
-  })
-
-  describe('#getDatabaseNames', function () {
-    it('should return array of database names', function (done) {
-      client.getDatabaseNames(function (err, dbs) {
-        if (err) return done(err)
-        assert(dbs instanceof Array)
-        assert.notEqual(dbs.indexOf(info.db.name), -1)
-        done()
-      })
-    })
-    it('should bubble errors through', function (done) {
-      failClient.getDatabaseNames(function (err) {
-        assert(err instanceof Error)
-        done()
-      })
-    })
-  })
-
-  describe('#disabledHosts', function () {
-    it('should return failed host', function (done) {
-      var hosts = failClient.getHostsDisabled()
-      assert.equal(hosts.length, 1)
-      assert.equal(hosts[0].name, info.server.host)
-      done()
-    })
-  })
-
-  describe('#createUser', function () {
-    it('should create a user without error', function (done) {
-      client.createUser(info.db.username, info.db.password, true, done)
-    })
-    it('should error when creating an existing user', function (done) {
-      client.createUser(info.db.username, info.db.password, function (err) {
-        assert(err instanceof Error)
-        done()
-      })
-    })
-  })
-
-  describe('#getUsers', function () {
-    it('should get an array of database users', function (done) {
-      client.getUsers(function (err, users) {
-        assert.equal(err, null)
-        assert(users instanceof Array)
-        assert.equal(users.length, 1)
-        done()
-      })
-    })
-
-    it('should error when deleting an existing user', function (done) {
-      failClient.getUsers(function (err) {
-        assert(err instanceof Error)
-        done()
-      })
-    })
-  })
-
-  describe('#setPassword', function () {
-    it('should update user password without error', function (done) {
-      client.setPassword(info.db.username, info.db.password, done)
-    })
-  })
-
-  describe('#grantPrivilege', function () {
-    it('should grant user privileges without error', function (done) {
-      client.grantPrivilege('READ', info.db.name, info.db.username, done)
-    })
-    it('should error when granting user privilege', function (done) {
-      client.grantPrivilege('BEER', info.db.name, info.db.username, function (err) {
-        assert(err instanceof Error)
-        done()
-      })
-    })
-  })
-
-  describe('#revokePrivilege', function () {
-    it('should revoke user privileges without error', function (done) {
-      client.revokePrivilege('READ', info.db.name, info.db.username, done)
-    })
-    it('should error when updating user privilege', function (done) {
-      client.revokePrivilege('BEER', info.db.name, info.db.username, function (err) {
-        assert(err instanceof Error)
-        done()
-      })
-    })
-  })
-
-  describe('#grantAdminPrivileges', function () {
-    it('should grant admin privileges without error', function (done) {
-      client.grantAdminPrivileges(info.db.username, done)
-    })
-    it('should error when granting admin privileges', function (done) {
-      client.grantAdminPrivileges('yourmum', function (err) {
-        assert(err instanceof Error)
-        done()
-      })
-    })
-  })
-
-  describe('#revokeAdminPrivileges', function () {
-    it('should revoke admin privileges without error', function (done) {
-      client.revokeAdminPrivileges(info.db.username, done)
-    })
-    it('should error when revoking admin privileges', function (done) {
-      client.revokeAdminPrivileges('yourmum', function (err) {
-        assert(err instanceof Error)
-        done()
-      })
-    })
-  })
-
-  describe('#dropUser', function () {
-    it('should delete a user without error', function (done) {
-      client.dropUser(info.db.username, done)
-    })
-    it('should error when deleting an existing user', function (done) {
-      client.dropUser(info.db.username, function (err) {
-        assert(err instanceof Error)
-        done()
-      })
-    })
-  })
-
-  describe('#createRetentionPolicy', function () {
-    it('should create a rentention policy', function (done) {
-      dbClient.createRetentionPolicy(info.db.retentionPolicy, info.db.name, '1d', 1, true, done)
-    })
-  })
-
-  describe('#getRetentionPolicies', function () {
-    it('should get an array of retention policies', function (done) {
-      client.getRetentionPolicies(info.db.name, function (err, rps) {
-        assert.equal(err, null)
-        assert(rps instanceof Array)
-        assert.equal(rps.length, 1)
-        done()
-      })
-    })
-  })
-
-  describe('#alterRetentionPolicy', function () {
-    it('should alter a rentention policy', function (done) {
-      dbClient.alterRetentionPolicy(info.db.retentionPolicy, info.db.name, '1h', 1, true, done)
-    })
-  })
-
-  describe('#writePoint', function () {
-    this.timeout(5000)
-
-    it('should write a generic point into the database', function (done) {
-      dbClient.writePoint(info.series.name, {value: 232, value2: 123}, {foo: 'bar', foobar: 'baz'}, done)
-    })
-
-    it('should write a generic point into the database', function (done) {
-      dbClient.writePoint(info.series.name, 1, {foo: 'bar', foobar: 'baz'}, done)
-    })
-
-    it('should write a generic point into the database', function (done) {
-      dbClient.writePoint(info.series.name, {time: 1234567890, value: 232}, {}, done)
-    })
-
-    it('should write a point with time into the database', function (done) {
-      dbClient.writePoint(info.series.name, {time: new Date(), value: 232}, {}, done)
-    })
-
-    it('should write a point with a string as value into the database', function (done) {
-      dbClient.writePoint(info.series.strName, {value: 'my test string'}, {}, done)
-    })
-
-    it('should write a point with a string as value into the database (using different method)', function (done) {
-      dbClient.writePoint(info.series.strName, 'my second test string', {}, done)
-    })
-
-    it('should write a point that has "length" in its keys', function (done) {
-      dbClient.writePoint(info.series.strName, {length: 3}, {length: '5'}, done)
-    })
-  })
-
-  describe('#writePoints', function () {
-    this.timeout(10000)
-    it('should write multiple points to the same time series, same column names', function (done) {
-      var points = [
-        [{value: 232}, {foobar: 'baz'}],
-        [{value: 212}, {foobar: 'baz'}],
-        [{value: 452}, {foobar: 'baz'}],
-        [{value: 122}]
-      ]
-      dbClient.writePoints(info.series.name, points, done)
-    })
-    it('should write multiple points to the same time series, differing column names', function (done) {
-      var points = [
-        [{value: 232}, {foobar: 'baz'}],
-        [{othervalue: 212}, {foobar: 'baz'}],
-        [{andanothervalue: 452}, {foobar: 'baz'}]
-      ]
-      dbClient.writePoints(info.series.name, points, done)
-    })
-  })
-
-  describe('#writeSeries', function () {
-    it('should write multiple points to multiple time series, same column names', function (done) {
-      var points = [
-        [{value: 232}, {foobar: 'baz'}],
-        [{value: 212}, {foobar: 'baz'}],
-        [{value: 452}, {foobar: 'baz'}],
-        [{value: 122}]
-      ]
-      var data = {
-        series1: points,
-        series2: points
-      }
-      dbClient.writeSeries(data, done)
-    })
-    it('should write multiple points to multiple time series, differing column names', function (done) {
-      var points = [
-        [{value: 232}, {foobar: 'baz'}],
-        [{othervalue: 212}, {foobar: 'baz'}],
-        [{andanothervalue: 452}, {foobar: 'baz'}]
-      ]
-      var data = {
-        series1: points,
-        series2: points
-      }
-      dbClient.writeSeries(data, done)
-    })
-    it('should write multiple points to multiple time series, differing column names, specified timestamps', function (done) {
-      var points = [
-        [{value: 232, time: 1234567787}, {foobar: 'baz'}],
-        [{othervalue: 212, time: 1234567777}, {foobar: 'baz'}],
-        [{andanothervalue: 452, time: 1234567747}, {foobar: 'baz'}]
-      ]
-      var data = {
-        series1: points,
-        series2: points
-      }
-      var response = dbClient._prepareValues(data)
-      var expected = 'series1,foobar=baz value=232 1234567787\nseries1,foobar=baz othervalue=212 1234567777\nseries1,foobar=baz andanothervalue=452 1234567747\nseries2,foobar=baz value=232 1234567787\nseries2,foobar=baz othervalue=212 1234567777\nseries2,foobar=baz andanothervalue=452 1234567747'
-      assert.equal(response, expected)
-      done()
-    })
-  })
-
-  describe('#query', function () {
-    it('should read a point from the database', function (done) {
-      dbClient.query('SELECT value FROM ' + info.series.name + ';', function (err, res) {
-        assert.equal(err, null)
-        assert(res instanceof Array)
-        assert.equal(res.length, 1)
-        assert(res[0].length >= 2)
-        assert.equal(res[0][0].value, 232)
-        done()
-      })
-    })
-  })
-
-  describe('#queryRaw', function () {
-    it('should read a point from the database and return raw values', function (done) {
-      dbClient.queryRaw('SELECT value FROM ' + info.series.name + ';', function (err, res) {
-        assert.equal(err, null)
-        assert(res instanceof Array)
-        assert.equal(res.length, 1)
-        assert.equal(res[0].series.length, 1)
-        done()
-      })
-    })
-  })
-
-  describe('#createContinuousQuery', function () {
-    it('should create a continuous query', function (done) {
-      dbClient.createContinuousQuery('testQuery', 'SELECT COUNT(value) INTO valuesCount_1h FROM ' + info.series.name + ' GROUP BY time(1h) ', function (err, res) {
-        assert.equal(err, null)
-        assert(res instanceof Array)
-        assert.equal(res.length, 1)
-        done()
-      })
-    })
-  })
-
-  describe('#getContinuousQueries', function () {
-    it('should fetch all continuous queries from the database', function (done) {
-      dbClient.getContinuousQueries(function (err, res) {
-        assert.equal(err, null)
-        assert(res instanceof Array)
-        assert.equal(res.length, 1)
-        done()
-      })
-    })
-  })
-
-  describe('#dropContinuousQuery', function () {
-    it('should drop the continuous query from the database', function (done) {
-      dbClient.getContinuousQueries(function (err, res) {
-        if (err) return done(err)
-        dbClient.dropContinuousQuery(res[0][0].name, function (err) {
-          assert.equal(err, null)
-          done()
-        })
-      })
-    })
-  })
-
-  describe('#getMeasurements', function () {
-    it('should return array of measurements', function (done) {
-      client.getMeasurements(function (err, measurements) {
-        if (err) return done(err)
-        assert(measurements instanceof Array)
-        assert.equal(measurements.length, 1)
-        done()
-      })
-    })
-  })
-
-  describe('#getSeries', function () {
-    it('should return array of series', function (done) {
-      client.getSeries(function (err, series) {
-        if (err) return done(err)
-        assert(series[0].values instanceof Array)
-        assert(series[0].values.length >= 3)
-        done()
-      })
-    })
-
-    it('should return array of series', function (done) {
-      client.getSeries(info.series.name, function (err, series) {
-        if (err) return done(err)
-        assert(series instanceof Array)
-        assert.equal(series[0].values.length, 3)
-        done()
-      })
-    })
-    it('should bubble errors through')
-  })
-
-  describe('#getSeriesNames', function () {
-    it('should return array of series names', function (done) {
-      client.getSeriesNames(function (err, series) {
-        if (err) return done(err)
-        assert(series instanceof Array)
-        assert.notEqual(series.indexOf(info.series.name), -1)
-        done()
-      })
-    })
-    it('should return array of series names from the db defined on connection', function (done) {
-      client.getSeriesNames(function (err, series) {
-        if (err) return done(err)
-        assert(series instanceof Array)
-        assert.notEqual(series.indexOf(info.series.name), -1)
-        done()
-      })
-    })
-    it('should bubble errors through')
-  })
-
-  describe('#dropSeries', function () {
-    this.timeout(25000)
-    it('should drop series', function (done) {
-      client.dropSeries('WHERE foobar="baz"', function (err) {
-        if (err) return done(err)
-        assert.equal(err, null)
-        done()
-      })
-    })
-    it('should bubble errors through', function (done) {
-      failClient.dropSeries(info.series.name, function (err) {
-        assert(err instanceof Error)
-        done()
-      })
-    })
-  })
-
-  describe('#dropMeasurement', function () {
-    this.timeout(25000)
-    it('should drop measurement', function (done) {
-      client.dropMeasurement(info.series.name, function (err) {
-        if (err) return done(err)
-        assert.equal(err, null)
-        done()
-      })
-    })
-    it('should bubble errors through', function (done) {
-      failClient.dropMeasurement(info.series.name, function (err) {
-        assert(err instanceof Error)
-        done()
       })
     })
   })
@@ -551,24 +286,331 @@ describe('InfluxDB', function () {
     })
   })
 
+  describe('#withDatabase', function () {
+    beforeEach(function (done) {
+      client.createDatabase(info.db.name, done)
+    })
+
+    afterEach(function (done) {
+      client.dropDatabase(info.db.name, done)
+    })
+
+    describe('#getDatabaseNames', function () {
+      it('should return array of database names', function (done) {
+        client.getDatabaseNames(function (err, dbs) {
+          if (err) return done(err)
+          assert(dbs instanceof Array)
+          assert.notEqual(dbs.indexOf(info.db.name), -1)
+          done()
+        })
+      })
+      it('should bubble errors through', function (done) {
+        failClient.getDatabaseNames(function (err) {
+          assert(err instanceof Error)
+          done()
+        })
+      })
+    })
+
+    describe('#retentionPolicies', function () {
+      beforeEach(function (done) {
+        dbClient.createRetentionPolicy(info.db.retentionPolicy, info.db.name, '1d', 1, true, done)
+      })
+      it('should get an array of retention policies', function (done) {
+        client.getRetentionPolicies(info.db.name, function (err, rps) {
+          assert.equal(err, null)
+          assert(rps instanceof Array)
+          assert.equal(rps.length, 1)
+          done()
+        })
+      })
+      it('should alter a rentention policy', function (done) {
+        dbClient.alterRetentionPolicy(info.db.retentionPolicy, info.db.name, '1h', 1, true, done)
+      })
+    })
+
+    describe('#writePoint', function () {
+      this.timeout(5000)
+
+      it('should write a generic point into the database', function (done) {
+        dbClient.writePoint(info.series.numName, {value: 232, value2: 123}, {foo: 'bar', foobar: 'baz'}, done)
+      })
+
+      it('should write a generic point into the database', function (done) {
+        dbClient.writePoint(info.series.numName, 1, {foo: 'bar', foobar: 'baz'}, done)
+      })
+
+      it('should write a generic point into the database', function (done) {
+        dbClient.writePoint(info.series.numName, {time: 1234567890, value: 232}, {}, done)
+      })
+
+      it('should write a point with time into the database', function (done) {
+        dbClient.writePoint(info.series.numName, {time: new Date(), value: 232}, {}, done)
+      })
+
+      it('should write a point with a string as value into the database', function (done) {
+        dbClient.writePoint(info.series.strName, {value: 'my test string'}, {}, done)
+      })
+
+      it('should write a point with a string as value into the database (using different method)', function (done) {
+        dbClient.writePoint(info.series.strName, 'my second test string', {}, done)
+      })
+
+      it('should write a point that has "length" in its keys', function (done) {
+        dbClient.writePoint(info.series.strName, {length: 3}, {length: '5'}, done)
+      })
+    })
+
+    describe('#writePoints', function () {
+      this.timeout(10000)
+      it('should write multiple points to the same time series, same column names', function (done) {
+        var points = [
+          [{value: 232}, {foobar: 'baz'}],
+          [{value: 212}, {foobar: 'baz'}],
+          [{value: 452}, {foobar: 'baz'}],
+          [{value: 122}]
+        ]
+        dbClient.writePoints(info.series.numName, points, done)
+      })
+      it('should write multiple points to the same time series, differing column names', function (done) {
+        var points = [
+          [{value: 232}, {foobar: 'baz'}],
+          [{othervalue: 212}, {foobar: 'baz'}],
+          [{andanothervalue: 452}, {foobar: 'baz'}]
+        ]
+        dbClient.writePoints(info.series.numName, points, done)
+      })
+    })
+
+    describe('#writeSeries', function () {
+      it('should write multiple points to multiple time series, same column names', function (done) {
+        var points = [
+          [{value: 232}, {foobar: 'baz'}],
+          [{value: 212}, {foobar: 'baz'}],
+          [{value: 452}, {foobar: 'baz'}],
+          [{value: 122}]
+        ]
+        var data = {
+          series1: points,
+          series2: points
+        }
+        dbClient.writeSeries(data, done)
+      })
+      it('should write multiple points to multiple time series, differing column names', function (done) {
+        var points = [
+          [{value: 232}, {foobar: 'baz'}],
+          [{othervalue: 212}, {foobar: 'baz'}],
+          [{andanothervalue: 452}, {foobar: 'baz'}]
+        ]
+        var data = {
+          series1: points,
+          series2: points
+        }
+        dbClient.writeSeries(data, done)
+      })
+      it('should write multiple points to multiple time series, differing column names, specified timestamps', function (done) {
+        var points = [
+          [{value: 232, time: 1234567787}, {foobar: 'baz'}],
+          [{othervalue: 212, time: 1234567777}, {foobar: 'baz'}],
+          [{andanothervalue: 452, time: 1234567747}, {foobar: 'baz'}]
+        ]
+        var data = {
+          series1: points,
+          series2: points
+        }
+        var response = dbClient._prepareValues(data)
+        var expected = 'series1,foobar=baz value=232 1234567787\nseries1,foobar=baz othervalue=212 1234567777\nseries1,foobar=baz andanothervalue=452 1234567747\nseries2,foobar=baz value=232 1234567787\nseries2,foobar=baz othervalue=212 1234567777\nseries2,foobar=baz andanothervalue=452 1234567747'
+        assert.equal(response, expected)
+        done()
+      })
+    })
+
+    describe('#withPointsInDB', function () {
+      beforeEach(function (done) {
+        dbClient.writePoint(info.series.numName, {value: 100, value2: 200}, {field1: 'f1', field2: 'f2'}, function () {
+          dbClient.writePoint(info.series.numName, {value: 101, value2: 201}, {field1: 'f1'}, function () {
+            dbClient.writePoint(info.series.strName, {value: 'my test string'}, {}, function () {
+              done()
+            })
+          })
+        })
+      })
+
+      describe('#query', function () {
+        it('should read a point from the database', function (done) {
+          dbClient.query('SELECT value FROM ' + info.series.numName + ';', function (err, res) {
+            assert.equal(err, null)
+            assert(res instanceof Array)
+            assert.equal(res.length, 1)
+            assert.equal(res[0].length, 2)
+            assert.equal(res[0][0].value, 100)
+            assert.equal(res[0][1].value, 101)
+            done()
+          })
+        })
+      })
+
+      describe('#queryRaw', function () {
+        it('should read a point from the database and return raw values', function (done) {
+          dbClient.queryRaw('SELECT value FROM ' + info.series.numName + ';', function (err, res) {
+            assert.equal(err, null)
+            assert(res instanceof Array)
+            assert.equal(res.length, 1)
+            assert.equal(res[0].series.length, 1)
+            done()
+          })
+        })
+      })
+
+      describe('#getMeasurements', function () {
+        it('should return array of measurements', function (done) {
+          client.getMeasurements(function (err, measurements) {
+            if (err) return done(err)
+            assert(measurements instanceof Array)
+            assert.equal(measurements.length, 1)
+            done()
+          })
+        })
+        it('should validate the returned measurements')
+      })
+
+      describe('#getSeries', function () {
+        it('should return array of series', function (done) {
+          client.getSeries(function (err, series) {
+            if (err) return done(err)
+            assert(series[0].values instanceof Array)
+            assert.equal(series[0].values.length, 2)
+            done()
+          })
+        })
+
+        it('should return array of series', function (done) {
+          client.getSeries(info.series.numName, function (err, series) {
+            if (err) return done(err)
+            assert(series instanceof Array)
+            assert.equal(series[0].values.length, 2)
+            done()
+          })
+        })
+        it('should bubble errors through')
+      })
+
+      describe('#getSeriesNames', function () {
+        it('should return array of series.numNames', function (done) {
+          client.getSeriesNames(function (err, series) {
+            if (err) return done(err)
+            assert(series instanceof Array)
+            assert.notEqual(series.indexOf(info.series.numName), -1)
+            done()
+          })
+        })
+        it('should return array of series.numNames from the db defined on connection', function (done) {
+          client.getSeriesNames(function (err, series) {
+            if (err) return done(err)
+            assert(series instanceof Array)
+            assert.notEqual(series.indexOf(info.series.numName), -1)
+            done()
+          })
+        })
+        it('should bubble errors through')
+      })
+
+      describe('#dropSeries', function () {
+        this.timeout(25000)
+        it('should drop series', function (done) {
+          client.dropSeries('WHERE foobar="baz"', function (err) {
+            if (err) return done(err)
+            assert.equal(err, null)
+            done()
+          })
+        })
+        it('should bubble errors through', function (done) {
+          failClient.dropSeries(info.series.numName, function (err) {
+            assert(err instanceof Error)
+            done()
+          })
+        })
+      })
+
+      describe('#dropMeasurement', function () {
+        this.timeout(25000)
+        it('should drop measurement', function (done) {
+          client.dropMeasurement(info.series.numName, function (err) {
+            if (err) return done(err)
+            assert.equal(err, null)
+            done()
+          })
+        })
+        it('should bubble errors through', function (done) {
+          failClient.dropMeasurement(info.series.numName, function (err) {
+            assert(err instanceof Error)
+            done()
+          })
+        })
+      })
+    })
+
+    describe('#createContinuousQuery', function () {
+      it('should create a continuous query', function (done) {
+        dbClient.createContinuousQuery('testQuery', 'SELECT COUNT(value) INTO valuesCount_1h FROM ' + info.series.numName + ' GROUP BY time(1h) ', function (err, res) {
+          assert.equal(err, null)
+          assert(res instanceof Array)
+          assert.equal(res.length, 1)
+          done()
+        })
+      })
+    })
+
+    describe('#withContinuousQueryInDB', function () {
+      beforeEach(function (done) {
+        dbClient.createContinuousQuery('testQuery', 'SELECT COUNT(value) INTO valuesCount_1h FROM ' + info.series.numName + ' GROUP BY time(1h) ', done)
+      })
+
+      describe('#getContinuousQueries', function () {
+        it('should fetch all continuous queries from the database', function (done) {
+          dbClient.getContinuousQueries(function (err, res) {
+            assert.equal(err, null)
+            assert(res instanceof Array)
+            assert.equal(res.length, 1)
+            // XXX Double check API / documentation, extra level of arrays?
+            // assert.equal(res[0].name, 'testQuery')
+            done()
+          })
+        })
+      })
+
+      describe('#dropContinuousQuery', function () {
+        it('should drop the continuous query from the database', function (done) {
+          dbClient.getContinuousQueries(function (err, res) {
+            if (err) return done(err)
+            dbClient.dropContinuousQuery(res[0][0].name, function (err) {
+              assert.equal(err, null)
+              done()
+            })
+          })
+        })
+      })
+    })
+  })
+
   describe('#failoverClient', function () {
     var normalClient
     var failoverClient
     var failoverdb = 'test_db_failover'
 
-    before(function(done) {
+    before(function (done) {
       normalClient = influx({host: info.server.host, port: info.server.port, username: info.server.username, password: info.server.password, database: failoverdb})
 
-      normalClient.createDatabase(failoverdb, function(err, response) {
+      normalClient.createDatabase(failoverdb, function (err, response) {
         assert.equal(err, null)
-        normalClient.writePoint(info.series.name, {value: 232, value2: 123}, {foo: 'bar', foobar: 'baz'}, function(err, response) {
+        normalClient.writePoint(info.series.numName, {value: 232, value2: 123}, {foo: 'bar', foobar: 'baz'}, function (err, response) {
           assert.equal(err, null)
           done()
         })
       })
     })
 
-    beforeEach(function(done) {
+    beforeEach(function (done) {
       failoverClient = influx({hosts: [
         {host: '192.168.255.1'},
         {host: '192.168.255.2'},
@@ -580,7 +622,7 @@ describe('InfluxDB', function () {
       done()
     })
 
-    after(function(done) {
+    after(function (done) {
       normalClient.dropDatabase(failoverdb, done)
     })
 
@@ -607,7 +649,7 @@ describe('InfluxDB', function () {
         failoverClient.setRequestTimeout(1000)
         // Should fail after ~3 seconds (third failed retry)
         this.timeout(4000)
-        failoverClient.query('SELECT value FROM ' + info.series.name + ';', function (err) {
+        failoverClient.query('SELECT value FROM ' + info.series.numName + ';', function (err) {
           assert(err instanceof Error)
           done()
         })
@@ -621,11 +663,11 @@ describe('InfluxDB', function () {
         failoverClient.setRequestTimeout(1000)
         // Should succeed on 5th server it tries (4s of timeouts)
         this.timeout(10000)
-        failoverClient.query('SELECT value FROM ' + info.series.name + ';', function (err, res) {
+        failoverClient.query('SELECT value FROM ' + info.series.numName + ';', function (err, res) {
           assert.equal(err, null)
           assert(res instanceof Array)
           assert.equal(res.length, 1)
-          assert(res[0].length == 1)
+          assert(res[0].length === 1)
           assert.equal(res[0][0].value, 232)
           done()
         })


### PR DESCRIPTION
This PR refactors the test suite so that there are no dependencies between tests. This allows you to run individual tests or sub-suites (i.e. `mocha --grep users`).

Prior to this series of commits, three tests were already failing:
  - InfluxDB #createDatabase should not throw an error if db already exists: `Error: database already exists`
  - InfluxDB #query failover should read a point from the database after the failed servers have been removed: `Uncaught AssertionError: { Error: connect ENETUNREACH 192.168.255.2:8086`
  - InfluxDB #dropDatabase should not error if database didn't exist: `Error: database not found: test_db`

The `#query failover` is fixed by permitting more retries so all the valid host is eventually selected in the first commit. The others are fixed individually by the final two commits.