### PR TITLE
Fix https test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
+sudo: required
+
+services:
+  - docker
+
 language: node_js
 node_js:
   - "6"
   - "5"
   - "4"
   - "0.12"
-env:
-  - INFLUX=0.13.0
-before_script:
-  - curl -O "https://dl.influxdata.com/influxdb/releases/influxdb_$(echo $INFLUX)_amd64.deb"
-  - sudo dpkg -i "influxdb_$(echo $INFLUX)_amd64.deb"
-  - sudo openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj '/C=US/ST=NewYork/L=NYC/O=Influx/CN=*' -keyout /server.pem -out /server.pem >/dev/null 2>&1
 
-  - sudo service influxdb start
-  - sleep 5
-script: npm run travis-test
+before_install:
+  - docker pull lab11/docker-influxdb:0.13-ci
+  - docker run -d -p 8083:8083 -p 8086:8086 -p 8085:8085 -p 8084:8084 -p 9085:9085 -p 9084:9084 --expose 8090 --expose 8099 lab11/docker-influxdb:0.13-ci
+
+script:
+  - npm run travis-test
+
 after_script:
   - cat ./coverage/lcov.info | ./node_modules/.bin/coveralls && rm -rf ./coverage

--- a/README.md
+++ b/README.md
@@ -446,9 +446,10 @@ As Jeff Atwood puts it... [Read the source, Luke](http://www.codinghorror.com/bl
 
 ## Testing
 
-Either install InfluxDB or use a docker container to run the service:
+The test suite uses a docker container that runs multiple instances of influxdb
+to validate HTTP, HTTPS, and HTTP Basic Auth.
 
-    docker run -d -p 8083:8083 -p 8086:8086 --expose 8090 --expose 8099 tutum/influxdb
+    docker run -d -p 8083:8083 -p 8086:8086 -p 8085:8085 -p 8084:8084 -p 9085:9085 -p 9084:9084 --expose 8090 --expose 8099 lab11/docker-influxdb:latest-ci
 
 Then to run the test harness use `npm test`.
 

--- a/test.js
+++ b/test.js
@@ -13,7 +13,12 @@ before(function (done) {
 
     assert.equal(major, 0)
     assert(minor >= 13)
-    done()
+
+    // Also double-check that basic https is working
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0' // allow self-signed cert
+    request('https://localhost:8084/ping', function (err, response, body) {
+      done(err)
+    })
   })
 })
 
@@ -706,41 +711,31 @@ describe('InfluxDB', function () {
       })
     })
   })
-})
 
-// todo:
-// HTTPS support didn't work, InfluxDB didn't start no matter what. needs to be solved asap
-/* describe('HTTPS connection', function() {
-  var client
+  describe('#HTTPS', function () {
+    var httpsClient
 
-  var dbName = 'https_db'
+    var dbName = 'https_db'
 
-  describe('connect and create test DB', function () {
+    describe('connect and create test DB', function () {
+      before(function () {
+        client = influx({host: info.server.host, port: info.server.port, username: info.server.username, password: info.server.password, database: info.db.name, retentionPolicy: info.db.retentionPolicy})
+        httpsClient = influx({
+          host: info.server.host,
+          port: 8084,
+          protocol: 'https',
+          username: info.server.username,
+          password: info.server.password,
+          precision: info.server.timePrecision
+        })
+      })
 
-    before(function() {
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // allow self-signed cert
-
-      client = influx({
-        host: 'localhost',
-        port: 8084,
-        protocol: 'https',
-        username: 'root',
-        password: 'root',
-        timePrecision: 'ms'
+      it('should create and delete database without error', function (done) {
+        httpsClient.createDatabase(dbName, function (err) {
+          if (err) return done(err)
+          httpsClient.dropDatabase(dbName, done)
+        })
       })
     })
-
-    it('should create a new database without error', function (done) {
-      client.createDatabase(dbName, done)
-    })
-
-    it('should throw an error if db already exists', function (done) {
-      client.createDatabase(dbName, function (err) {
-        assert(err instanceof Error)
-        done()
-      })
-    })
-
   })
 })
-*/


### PR DESCRIPTION
**Note: This depends on PR #162**

Change the travis test harness to use a Docker image. This Docker image runs multiple influxdb instances so that it can test against HTTP, HTTPS, and (eventually) HTTP Basic Auth.