### PR TITLE
Sort tags before writing, for performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -313,6 +313,12 @@ InfluxDB.prototype._createKeyValueString = function (object) {
   return output.join(',')
 }
 
+/**
+ * Return a sorted string of comma-separated key=value tags, with escaped values
+ * @param object
+ * @returns {string}
+ * @private
+ */
 InfluxDB.prototype._createKeyTagString = function (object) {
   var output = []
   _.forOwn(object, function (value, key) {
@@ -322,7 +328,8 @@ InfluxDB.prototype._createKeyTagString = function (object) {
       output.push(key + '=' + value)
     }
   })
-  return output.join(',')
+  // "For best performance you should sort tags by key before sending them to the database."
+  return output.sort().join(',')
 }
 
 InfluxDB.prototype._prepareValues = function (series) {

--- a/test.js
+++ b/test.js
@@ -112,7 +112,7 @@ describe('InfluxDB', function () {
     describe('#_createKeyTagString', function () {
       it('should build a properly formatted string', function () {
         var str = client._createKeyTagString({tag_1: 'value', tag2: 'value value', tag3: 'value,value'})
-        assert.equal(str, 'tag_1=value,tag2=value\\ value,tag3=value\\,value')
+        assert.equal(str, 'tag2=value\\ value,tag3=value\\,value,tag_1=value')  // tags should be sorted
       })
     })
 


### PR DESCRIPTION
Per [the docs](https://docs.influxdata.com/influxdb/v1.0/write_protocols/line_protocol_tutorial/#tag-set),

> For best performance you should sort tags by key before sending them to the database.