### PR TITLE
Replace `request` with the much ligther `got` module

### DIFF
--- a/lib/InfluxRequest.js
+++ b/lib/InfluxRequest.js
@@ -1,4 +1,4 @@
-var request = require('request')
+var got = require('got')
 var _ = require('lodash')
 var url = require('url')
 
@@ -13,6 +13,7 @@ function InfluxRequest (options) {
     timeout: null
   }
   this.setRequestTimeout(options.requestTimeout)
+  // our custom options
   this.options = {
     failoverTimeout: options.failoverTimeout || 60000,
     maxRetries: options.maxRetries || 2
@@ -106,20 +107,18 @@ InfluxRequest.prototype._request = function (options, callback) {
   // need to store the original path, in case we need to re-submit the request onError and change the host
   if (!requestOptions.originalUrl) requestOptions.originalUrl = requestOptions.url
   requestOptions.url = this.url(host, requestOptions.originalUrl)
-  requestOptions.retries++
-  request(requestOptions, function (err, response, body) {
-    self._parseCallback(err, response, body, requestOptions, callback)
-  })
-}
-
-InfluxRequest.prototype._parseCallback = function (err, response, body, requestOptions, callback) {
-  if (err && resubmitErrorCodes.indexOf(err.code) !== -1) {
-    this.disableHost(requestOptions.host)
-    if (this.options.maxRetries >= requestOptions.retries && this.hostIsAvailable()) {
-      return this._request(requestOptions, callback)
+  requestOptions.retries++  // TODO request() would ignore the `.retries` option (which is needed by _parseErrorCallback), but got() does have a 'retries' option
+  got(requestOptions.url, requestOptions).then(function (response) {
+    return callback(null, response, response.body)
+  }).catch(function (error) {
+    if (resubmitErrorCodes.indexOf(error.code) !== -1) {
+      self.disableHost(requestOptions.host)
+      if (self.options.maxRetries >= requestOptions.retries && self.hostIsAvailable()) {
+        return self._request(requestOptions, callback)
+      }
     }
-  }
-  return callback(err, response, body)
+    return callback(error)
+  })
 }
 
 InfluxRequest.prototype.get = function (options, callback) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "got": "^6.5.0",
     "lodash": "^4.11.1",
     "request": "2.x"
   },

--- a/test.js
+++ b/test.js
@@ -1,12 +1,11 @@
 /* eslint-env mocha */
 var influx = require('./')
 var assert = require('assert')
-var request = require('request')
+var got = require('got')
 
 before(function (done) {
   // Before doing anything validate that InfluxDB is a recent version and running
-  request('http://localhost:8086/ping', function (err, response, body) {
-    if (err) return done(err)
+  got('http://localhost:8086/ping').then(function (response) {
     var version = response.headers['x-influxdb-version']
     var major = version.split('.')[0]
     var minor = version.split('.')[1]
@@ -14,6 +13,8 @@ before(function (done) {
     assert.equal(major, 0)
     assert(minor >= 13)
     done()
+  }).catch(function (error) {
+    return done(error)
   })
 })
 

--- a/test.js
+++ b/test.js
@@ -525,7 +525,7 @@ describe('InfluxDB', function () {
       })
 
       describe('#getSeries', function () {
-        it('should return array of series', function (done) {
+        it('getSeries without name should return array of series', function (done) {
           client.getSeries(function (err, series) {
             if (err) return done(err)
             var expected = [ {


### PR DESCRIPTION
WIP fix for #177 

All tests pass when debugging in WebStorm. 5 tests fail when running `npm test` - can someone help figure out why, maybe @ppannuto?

Also, we keep a `retries` key in our requestOptions, and `request()` didn't support a `retries` option. `got()` does have one such option.