### PR TITLE
Replaced `request` with `node-fetch`

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,14 +109,20 @@ InfluxDB.prototype._parseResults = function (response, callback) {
   return callback(null, results)
 }
 
+/**
+ * Return a function that calls the callback with either the error or the results
+ * @param callback
+ * @returns {Function}
+ * @private
+ */
 InfluxDB.prototype._parseCallback = function (callback) {
   return function (err, res, body) {
     if (typeof callback === 'undefined') return
     if (err) {
       return callback(err)
     }
-    if (res.statusCode < 200 || res.statusCode >= 300) {
-      return callback(new Error(body.error || (typeof body === 'object' ? JSON.stringify(body) : (body || res.statusCode))))
+    if (res.status < 200 || res.status >= 300) {
+      return callback(new Error(body.error || (typeof body === 'object' ? JSON.stringify(body) : (body || res.status))))
     }
 
     // Look for errors in the response body
@@ -173,8 +179,7 @@ InfluxDB.prototype.queryDB = function (query, options, callback) {
   var args = resolveOptCallback(options, callback)
 
   this.request.get({
-    url: this.url('query', args.options, {q: query}),
-    json: true
+    url: this.url('query', args.options, {q: query})
   }, this._parseCallback(args.callback))
 }
 
@@ -189,8 +194,7 @@ InfluxDB.prototype.updateDB = function (query, options, callback) {
   var args = resolveOptCallback(options, callback)
 
   this.request.post({
-    url: this.url('query', args.options, {q: query}),
-    json: true
+    url: this.url('query', args.options, {q: query})
   }, this._parseCallback(args.callback))
 }
 

--- a/lib/InfluxRequest.js
+++ b/lib/InfluxRequest.js
@@ -1,4 +1,4 @@
-var fetch = require('node-fetch')
+var fetch = require('isomorphic-fetch')
 var _ = require('lodash')
 var url = require('url')
 

--- a/lib/InfluxRequest.js
+++ b/lib/InfluxRequest.js
@@ -2,7 +2,9 @@ var fetch = require('node-fetch')
 var _ = require('lodash')
 var url = require('url')
 
-var resubmitErrorCodes = ['network timeout', 'ETIMEDOUT', 'ESOCKETTIMEDOUT', 'ECONNRESET', 'ECONNREFUSED', 'EHOSTUNREACH']
+// node-fetch has its [custom error types](https://github.com/bitinn/node-fetch/pull/99#issuecomment-205461546),
+// and passes through system errors, which [makes errors harder to check](https://github.com/bitinn/node-fetch/issues/7)
+var resubmitErrorTypes = ['request-timeout', 'body-timeout', 'ETIMEDOUT', 'ESOCKETTIMEDOUT', 'ECONNRESET', 'ECONNREFUSED', 'EHOSTUNREACH']
 
 function InfluxRequest (options) {
   if (!options) options = {}
@@ -115,14 +117,13 @@ InfluxRequest.prototype._request = function (options, callback) {
   }).then(function (body) {
     return callback(null, theResponse, body)
   }).catch(function (error) {
-    // This is more complicated than it should be because node-fetch refused to implement error codes
-    // https://github.com/bitinn/node-fetch/issues/7#issuecomment-204760379
-    for (var i = 0; i < resubmitErrorCodes.length; i++) {
-      if (error.message.indexOf(resubmitErrorCodes[i]) > -1) {
-        self.disableHost(requestOptions.host)
-        if (self.options.maxRetries >= requestOptions.retries && self.hostIsAvailable()) {
-          return self._request(requestOptions, callback)
-        }
+    // This is slightly more complicated than it should be because node-fetch has its own custom error types:
+    // https://github.com/bitinn/node-fetch/issues/7#issuecomment-249406309
+    if (error.type === 'system') error.type = error.code
+    if (resubmitErrorTypes.indexOf(error.type) > -1) {
+      self.disableHost(requestOptions.host)
+      if (self.options.maxRetries >= requestOptions.retries && self.hostIsAvailable()) {
+        return self._request(requestOptions, callback)
       }
     }
     return callback(error)

--- a/lib/InfluxRequest.js
+++ b/lib/InfluxRequest.js
@@ -2,7 +2,7 @@ var fetch = require('node-fetch')
 var _ = require('lodash')
 var url = require('url')
 
-var resubmitErrorCodes = ['ETIMEDOUT', 'ESOCKETTIMEDOUT', 'ECONNRESET', 'ECONNREFUSED', 'EHOSTUNREACH']
+var resubmitErrorCodes = ['network timeout', 'ETIMEDOUT', 'ESOCKETTIMEDOUT', 'ECONNRESET', 'ECONNREFUSED', 'EHOSTUNREACH']
 
 function InfluxRequest (options) {
   if (!options) options = {}
@@ -111,15 +111,18 @@ InfluxRequest.prototype._request = function (options, callback) {
   var theResponse
   fetch(requestOptions.url, requestOptions).then(function (response) {
     theResponse = response
-    return response.text()
+    return response.json()
   }).then(function (body) {
-    body = body === '' ? {} : JSON.parse(body)  // workaround for https://github.com/bitinn/node-fetch/issues/165
     return callback(null, theResponse, body)
   }).catch(function (error) {
-    if (resubmitErrorCodes.indexOf(error.code) !== -1) {
-      self.disableHost(requestOptions.host)
-      if (self.options.maxRetries >= requestOptions.retries && self.hostIsAvailable()) {
-        return self._request(requestOptions, callback)
+    // This is more complicated than it should be because node-fetch refused to implement error codes
+    // https://github.com/bitinn/node-fetch/issues/7#issuecomment-204760379
+    for (var i = 0; i < resubmitErrorCodes.length; i++) {
+      if (error.message.indexOf(resubmitErrorCodes[i]) > -1) {
+        self.disableHost(requestOptions.host)
+        if (self.options.maxRetries >= requestOptions.retries && self.hostIsAvailable()) {
+          return self._request(requestOptions, callback)
+        }
       }
     }
     return callback(error)

--- a/lib/InfluxRequest.js
+++ b/lib/InfluxRequest.js
@@ -1,4 +1,4 @@
-var request = require('request')
+var fetch = require('node-fetch')
 var _ = require('lodash')
 var url = require('url')
 
@@ -13,6 +13,7 @@ function InfluxRequest (options) {
     timeout: null
   }
   this.setRequestTimeout(options.requestTimeout)
+  // our custom options
   this.options = {
     failoverTimeout: options.failoverTimeout || 60000,
     maxRetries: options.maxRetries || 2
@@ -106,20 +107,23 @@ InfluxRequest.prototype._request = function (options, callback) {
   // need to store the original path, in case we need to re-submit the request onError and change the host
   if (!requestOptions.originalUrl) requestOptions.originalUrl = requestOptions.url
   requestOptions.url = this.url(host, requestOptions.originalUrl)
-  requestOptions.retries++
-  request(requestOptions, function (err, response, body) {
-    self._parseCallback(err, response, body, requestOptions, callback)
-  })
-}
-
-InfluxRequest.prototype._parseCallback = function (err, response, body, requestOptions, callback) {
-  if (err && resubmitErrorCodes.indexOf(err.code) !== -1) {
-    this.disableHost(requestOptions.host)
-    if (this.options.maxRetries >= requestOptions.retries && this.hostIsAvailable()) {
-      return this._request(requestOptions, callback)
+  requestOptions.retries++  // fetch() ignores the `.retries` option
+  var theResponse
+  fetch(requestOptions.url, requestOptions).then(function (response) {
+    theResponse = response
+    return response.text()
+  }).then(function (body) {
+    body = body === '' ? {} : JSON.parse(body)  // workaround for https://github.com/bitinn/node-fetch/issues/165
+    return callback(null, theResponse, body)
+  }).catch(function (error) {
+    if (resubmitErrorCodes.indexOf(error.code) !== -1) {
+      self.disableHost(requestOptions.host)
+      if (self.options.maxRetries >= requestOptions.retries && self.hostIsAvailable()) {
+        return self._request(requestOptions, callback)
+      }
     }
-  }
-  return callback(err, response, body)
+    return callback(error)
+  })
 }
 
 InfluxRequest.prototype.get = function (options, callback) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^4.11.1",
-    "request": "2.x"
+    "node-fetch": "^1.6.2"
   },
   "devDependencies": {
     "coveralls": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^4.11.1",
-    "node-fetch": "^1.6.2"
+    "isomorphic-fetch": "^2.2.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.1",

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 var influx = require('./')
 var assert = require('assert')
-var fetch = require('node-fetch')
+var fetch = require('isomorphic-fetch')
 
 before(function (done) {
   // Before doing anything validate that InfluxDB is a recent version and running

--- a/test.js
+++ b/test.js
@@ -1,19 +1,20 @@
 /* eslint-env mocha */
 var influx = require('./')
 var assert = require('assert')
-var request = require('request')
+var fetch = require('node-fetch')
 
 before(function (done) {
   // Before doing anything validate that InfluxDB is a recent version and running
-  request('http://localhost:8086/ping', function (err, response, body) {
-    if (err) return done(err)
-    var version = response.headers['x-influxdb-version']
+  fetch('http://localhost:8086/ping').then(function (response) {
+    var version = response.headers.get('x-influxdb-version')
     var major = version.split('.')[0]
     var minor = version.split('.')[1]
 
     assert.equal(major, 0)
     assert(minor >= 13)
     done()
+  }).catch(function (error) {
+    return done(error)
   })
 })
 

--- a/test.js
+++ b/test.js
@@ -740,7 +740,7 @@ describe('InfluxDB', function () {
 
     describe('#queryFailover', function () {
       it('should read a point from the database after the failed servers have been removed', function (done) {
-        // FIXME: This is a bit of a hack, but there's currently no API to dynamically change this
+        // FIXME: This is a bit of a hack, but there's currently no API to dynamically change maxRetries
         failoverClient.request.options.maxRetries = 5
         failoverClient.setRequestTimeout(1000)
         // Should succeed on 5th server it tries (4s of timeouts)


### PR DESCRIPTION
`node-tech` for use with isomorphic-fetch in browsers, instead of [`got`](https://github.com/node-influx/node-influx/pull/186).

* [x] Fix the [node-fetch issue with 204 no-content](https://github.com/bitinn/node-fetch/issues/165)
* [x] Fix last test - All tests pass, except the last hacky one. What exactly does the second "this" refer to in [the comment](https://github.com/node-influx/node-influx/blob/master/test.js#L742)?