### PR TITLE
Fix #206: globalAgent ignored during HTTPS communication

### DIFF
--- a/index.js
+++ b/index.js
@@ -428,7 +428,7 @@ InfluxDB.prototype.writeSeries = function (series, options, callback) {
 
   this.request.post({
     url: this.url('write', args.options),
-    pool: typeof args.options.pool !== 'undefined' ? args.options.pool : {},
+    pool: typeof args.options.pool !== 'undefined' ? args.options.pool : undefined,
     body: this._prepareValues(series)
   }, this._parseCallback(args.callback))
 }


### PR DESCRIPTION
When an empty object is set for the pool in the options for the request module, a conditional fails which creates a new HTTPS agent rather than using the globalAgent that may have injected certificate authorities or global options.