### PR TITLE
Fix incorrect content-length header cause request body being chopped

### DIFF
--- a/src/pool.ts
+++ b/src/pool.ts
@@ -342,7 +342,6 @@ export class Pool {
     const once = doOnce();
     const host = this.getHost();
     const req = request(<any> { // <any> DefinitelyTyped has not update defs yet
-      headers: { 'content-length': options.body ? options.body.length : 0 },
       hostname: host.url.hostname,
       method: options.method,
       path,


### PR DESCRIPTION
See #244 

The way of body's length measurement is wrong when the body contains multi-bytes characters.

Ignore the `content-length` header, it will automatically use `Transfer-Encoding: chunked`, works fine.