### PR TITLE
fix get wrong http request body length

### DIFF
--- a/src/pool.ts
+++ b/src/pool.ts
@@ -344,7 +344,7 @@ export class Pool {
     const once = doOnce();
     const host = this.getHost();
     const req = request(Object.assign({
-      headers: { 'content-length': options.body ? options.body.length : 0 },
+      headers: { 'content-length': options.body ? new Buffer(options.body).length : 0 },
       hostname: host.url.hostname,
       method: options.method,
       path,

--- a/test/unit/pool.test.ts
+++ b/test/unit/pool.test.ts
@@ -76,9 +76,8 @@ describe('pool', () => {
     const p = createPool();
     const body = '\u00FF';
     p.addHost('https://httpbin.org/post');
-    p.json({ method: 'POST', path: '/post', body: body }).then(data => {
-      expect(data['data']).to.equal(body);
-    });
+    p.json({ method: 'POST', path: '/post', body: body })
+      .then(data => expect(data.data).to.equal(body));
   });
 
   describe('request generators', () => {

--- a/test/unit/pool.test.ts
+++ b/test/unit/pool.test.ts
@@ -72,6 +72,15 @@ describe('pool', () => {
     });
   });
 
+  it('valid request data content length', () => {
+    const p = createPool();
+    const body = '\u00FF';
+    p.addHost('https://httpbin.org/post');
+    p.json({ method: 'POST', path: '/post', body: body }).then(data => {
+      expect(data['data']).to.equal(body);
+    });
+  });
+
   describe('request generators', () => {
     it('makes a text request', () => {
       return pool.text({ method: 'GET', path: '/pool/json' })


### PR DESCRIPTION
In fact, the length of string in node may not be equal the actual string length, and the server will get wrong sql,so use Buffer to get the string length.

example:

var text='你好' // this string is chinese
console.log(text.length) will be 2,but actual it's  6.
