### PR TITLE
Show Continuous Queries

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -748,7 +748,7 @@ export class InfluxDB {
   }
 
   /**
-   * Returns a list of continous queries in the database.
+   * Returns a list of continuous queries in the database.
    * @return {Promise<void>}
    * @example
    * influx.showContinuousQueries()

--- a/src/index.ts
+++ b/src/index.ts
@@ -590,7 +590,7 @@ export class InfluxDB {
    *   })
    * })
    */
-  public getUsers(): Promise<{ user: string, admin: boolean}[]> {
+  public getUsers(): Promise<IResults<{ user: string, admin: boolean}>> {
     return this.pool.json(this.getQueryOpts({ q: 'show users' })).then(parseSingle);
   }
 
@@ -875,13 +875,13 @@ export class InfluxDB {
    *   ])
    * })
    */
-  public showRetentionPolicies(database: string = this.defaultDB()): Promise<{
+  public showRetentionPolicies(database: string = this.defaultDB()): Promise<IResults<{
     default: boolean, // tslint:disable-line
     duration: string,
     name: string,
     replicaN: number,
     shardGroupDuration: string,
-  }[]> {
+  }>> {
     return this.pool.json(this.getQueryOpts({
       q: `show retention policies on ${grammar.escape.quoted(database)}`,
     }, 'GET')).then(parseSingle);

--- a/src/index.ts
+++ b/src/index.ts
@@ -731,6 +731,7 @@ export class InfluxDB {
 
   /**
    * Returns a list of continous queries in the database.
+   * @deprecated Use showContinuousQueries instead.
    * @param {String} [database] If not provided, uses the default database.
    * @return {Promise<void>}
    * @example
@@ -742,6 +743,21 @@ export class InfluxDB {
   }>> {
     return this.pool.json(this.getQueryOpts({
       db: database,
+      q: 'show continuous queries',
+    })).then(parseSingle);
+  }
+
+  /**
+   * Returns a list of continous queries in the database.
+   * @return {Promise<void>}
+   * @example
+   * influx.showContinuousQueries()
+   */
+  public showContinuousQueries(): Promise<IResults<{
+    name: string,
+    query: string,
+  }>> {
+    return this.pool.json(this.getQueryOpts({
       q: 'show continuous queries',
     })).then(parseSingle);
   }

--- a/src/results.ts
+++ b/src/results.ts
@@ -200,8 +200,6 @@ export function assertNoErrors(res: IResponse) {
       throw new ResultError(error);
     }
   }
-
-  return res;
 }
 
 /**

--- a/test/integrate/admin.test.ts
+++ b/test/integrate/admin.test.ts
@@ -119,7 +119,7 @@ describe('administrative actions', () => {
 
     it('creates continuous queries', () => {
       return db.createContinuousQuery('7d_perf', sampleQuery)
-        .then(() => db.showContinousQueries())
+        .then(() => db.showContinuousQueries())
         .then(queries => {
           expect(queries.slice()).to.deep.equal([
             { name: '7d_perf', query: 'CREATE CONTINUOUS QUERY "7d_perf" ON '
@@ -131,9 +131,9 @@ describe('administrative actions', () => {
 
     it('drops continuous queries', () => {
       return db.createContinuousQuery('7d_perf', sampleQuery)
-        .then(() => db.showContinousQueries())
+        .then(() => db.showContinuousQueries())
         .then(() => db.dropContinuousQuery('7d_perf'))
-        .then(() => db.showContinousQueries())
+        .then(() => db.showContinuousQueries())
         .then(queries => expect(queries).to.have.length(0));
     });
   });

--- a/test/unit/influx.test.ts
+++ b/test/unit/influx.test.ts
@@ -429,8 +429,8 @@ describe('influxdb', () => {
       it('queries correctly', () => {
         expectQuery('json', { q: 'show continuous queries' }, 'GET');
         return influx.showContinuousQueries();
-      })
-    })
+      });
+    });
 
     describe('.showContinousQueries()', () => {
       // This should be removed in the future as the users should use showContinuousQueries instead

--- a/test/unit/influx.test.ts
+++ b/test/unit/influx.test.ts
@@ -425,7 +425,15 @@ describe('influxdb', () => {
       });
     });
 
+    describe('.showContinuousQueries()', () => {
+      it('queries correctly', () => {
+        expectQuery('json', { q: 'show continuous queries' }, 'GET');
+        return influx.showContinuousQueries();
+      })
+    })
+
     describe('.showContinousQueries()', () => {
+      // This should be removed in the future as the users should use showContinuousQueries instead
       it('queries correctly', () => {
         expectQuery('json', { q: 'show continuous queries', db: 'my_db' }, 'GET');
         return influx.showContinousQueries('my_db');


### PR DESCRIPTION
- Fixing #274 
- Using suggestions of #270 
- Marking the original `showContinousQueries` as deprecated
- Changing the tests in test/integrate/admin.test.ts to use `showContinuousQueries` instead of `showContinousQueries`
- Fix build errors caused by incorrectly specified types