### PR TITLE
Adding a TimeFormat options to query to return ISODate or Timestamp

### DIFF
--- a/src/grammar/times.ts
+++ b/src/grammar/times.ts
@@ -63,6 +63,8 @@ export interface INanoDate extends Date {
 
 export type TimePrecision = 'n' | 'u' | 'ms' | 's' | 'm' | 'h';
 
+export type TimeFormat = 'ISO' | 'Timestamp';
+
 /**
  * Precision is a map of available Influx time precisions.
  * @type {Object.<String, String>}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1056,7 +1056,7 @@ export class InfluxDB {
       options = Object.assign({}, options); // avoid mutating
       delete options.precision;
     }
-    console.log('timeFormat' + options.timeFormat);
+    
     return this.queryRaw(query, options).then(res => parse(res, options.precision, options.timeFormat));
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1082,7 +1082,7 @@ export class InfluxDB {
     if (query instanceof Array) {
       query = query.join(';');
     }
-    console.log('timeFormat' + options.timeFormat);
+
     return this.pool.json(this.getQueryOpts({
       db: database,
       epoch: options.precision,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const defaultOptions: IClusterConfig = Object.freeze({
 });
 
 export * from './builder';
-export { INanoDate, FieldType, Precision, Raw, TimePrecision, escape, toNanoDate } from './grammar';
+export { INanoDate, FieldType, Precision, Raw, TimePrecision, TimeFormat, escape, toNanoDate } from './grammar';
 export { ISchemaOptions } from './schema';
 export { IPingStats, IPoolOptions } from './pool';
 export { IResults, IResponse, ResultError } from './results';
@@ -1052,11 +1052,11 @@ export class InfluxDB {
     // If the consumer asked explicitly for nanosecond precision parsing,
     // remove that to cause Influx to give us ISO dates that
     // we can parse correctly.
-    if (options.precision === 'n') {
+    if (options.precision === 'n' && options.timeFormat === 'ISO') {
       options = Object.assign({}, options); // avoid mutating
       delete options.precision;
     }
-
+    console.log('timeFormat' + options.timeFormat);
     return this.queryRaw(query, options).then(res => parse(res, options.precision, options.timeFormat));
   }
 
@@ -1082,7 +1082,7 @@ export class InfluxDB {
     if (query instanceof Array) {
       query = query.join(';');
     }
-
+    console.log('timeFormat' + options.timeFormat);
     return this.pool.json(this.getQueryOpts({
       db: database,
       epoch: options.precision,

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,8 @@ export interface IQueryOptions {
    * database is not provided in Influx.
    */
   database?: string;
+
+  timeFormat?: grammar.TimeFormat;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1055,7 +1055,7 @@ export class InfluxDB {
       delete options.precision;
     }
 
-    return this.queryRaw(query, options).then(res => parse(res, options.precision));
+    return this.queryRaw(query, options).then(res => parse(res, options.precision, options.timeFormat));
   }
 
   /**

--- a/src/results.ts
+++ b/src/results.ts
@@ -221,7 +221,7 @@ export function assertNoErrors(res: IResponse) {
  */
 export function parse<T>(res: IResponse, precision?: TimePrecision, timeFormat?: TimeFormat): IResults<T>[] | IResults<T> {
   assertNoErrors(res);
-  console.log('timeFormat' + timeFormat);
+  
   if (res.results.length === 1) { // normalize case 3
     return parseInner(res.results[0].series, precision, timeFormat);
   } else {

--- a/src/results.ts
+++ b/src/results.ts
@@ -100,12 +100,13 @@ function parseInner(series: IResponseSeries[] = [], precision?: TimePrecision, t
       const obj: Row = {};
       for (let j = 0; j < columns.length; j += 1) {
         if (columns[j] === 'time') {
-          if (timeFormat == 'ISO')
+          if (timeFormat === 'ISO') {
             obj.time = isoOrTimeToDate(<number | string> values[k][j], precision);
-          else if (timeFormat == 'Timestamp')
+          } else if (timeFormat === 'Timestamp') { 
             obj.time = values[k][j];
-          else 
+          } else {
             obj.time = isoOrTimeToDate(<number | string> values[k][j], precision);
+          }
         } else {
           obj[columns[j]] = values[k][j];
         }
@@ -220,9 +221,9 @@ export function assertNoErrors(res: IResponse) {
  */
 export function parse<T>(res: IResponse, precision?: TimePrecision, timeFormat?: TimeFormat): IResults<T>[] | IResults<T> {
   assertNoErrors(res);
-
+  console.log('timeFormat' + timeFormat);
   if (res.results.length === 1) { // normalize case 3
-    return parseInner(res.results[0].series, precision);
+    return parseInner(res.results[0].series, precision, timeFormat);
   } else {
     return res.results.map(result => parseInner(result.series, precision, timeFormat));
   }


### PR DESCRIPTION
I've used node-influx in many projects, I've had requirements to return timestamps. The module only return ISO dates. I've added the option to return either ISODate or Timestamp.
The timeFormat option can be 'ISO' or 'Timestamp'. Defaults to 'ISO'. The timestamps return are in the desired precision specified in precision option