### PR TITLE
extract line protocol serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:dist": "npm run clean && tsc && cp -R test/fixture lib/test",
     "build:doc": "npm run clean && tsc -m es2015 -t es6 --moduleResolution node && esdoc -c esdoc.json",
     "clean": "run-script-os",
-    "clean:darwin:linux": rm -rf coverage doc lib",
+    "clean:darwin:linux": "rm -rf coverage doc lib",
     "clean:win32": "rd /s /q coverage & rd /s /q doc & rd /s /q lib",
     "prepare": "npm run clean && tsc -d",
     "fmt": "prettier --single-quote --trailing-comma all --print-width 100 --write \"{src,test,examples}/**/*.ts\" && npm run test:lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -71,5 +71,10 @@
     "tslint-microsoft-contrib": "^5.0.2",
     "typescript": "^2.7.1",
     "webpack": "^3.11.0"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "trailingComma": "all",
+    "printWidth": 100
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "build:dist": "npm run clean && tsc && cp -R test/fixture lib/test",
     "build:doc": "npm run clean && tsc -m es2015 -t es6 --moduleResolution node && esdoc -c esdoc.json",
-    "clean": "rm -rf coverage doc lib",
+    "clean": "run-script-os",
+    "clean:darwin:linux": rm -rf coverage doc lib",
+    "clean:win32": "rd /s /q coverage & rd /s /q doc & rd /s /q lib",
     "prepare": "npm run clean && tsc -d",
     "fmt": "prettier --single-quote --trailing-comma all --print-width 100 --write \"{src,test,examples}/**/*.ts\" && npm run test:lint -- --fix",
     "test": "npm-run-all --parallel test:lint test:unit test:integrate",
@@ -63,6 +65,7 @@
     "npm-run-all": "^4.0.2",
     "opn-cli": "^3.1.0",
     "prettier": "^1.4.4",
+		"run-script-os": "^1.0.3",
     "sinon": "^4.3.0",
     "sinon-chai": "^2.8.0",
     "stream-http": "github:node-influx/stream-http",

--- a/src/line-protocol.ts
+++ b/src/line-protocol.ts
@@ -1,0 +1,74 @@
+import * as grammar from './grammar';
+import { IPoint } from './index';
+import { coerceBadly, Schema } from './schema';
+
+export interface ISerializePointOptions {
+  /**
+   * Precision at which the points are written, defaults to nanoseconds 'n'.
+   */
+  precision?: grammar.TimePrecision;
+
+  /**
+   * Map of Schema instances for measurements.
+   */
+  schema?: { [measurement: string]: Schema };
+}
+
+/**
+ * Serialise an IPoint into a string conforming to the Influx line protocol.
+ *
+ * Please see the IPoint and ISerializePointOptions types for a
+ * full list of possible options.
+ *
+ * @param {IPoint} point
+ * @param {IWriteOptions} [options]
+ * @return {string}
+ * @example
+ * // serialise a point object into influx line protocol
+ * // without using a schema
+ * const line = influx.serializePoint(
+ *   {
+ *     measurement: 'perf',
+ *     tags: { host: 'box1.example.com' },
+ *     fields: { cpu: getCpuUsage(), mem: getMemUsage() },
+ *   }
+ * )
+ *
+ * // you can manually specify the precision,
+ * // and schema.
+ * const line = influx.serializePoint(
+ *   {
+ *     measurement: 'perf',
+ *     tags: { host: 'box1.example.com' },
+ *     fields: { cpu: getCpuUsage(), mem: getMemUsage() },
+ *     timestamp: getLastRecordedTime(),
+ *   }, {
+ *     precision: 's',
+ *     schema: { perf: /* schema instance /* },
+ *   }
+ * )
+ */
+export function serializePoint(point: IPoint, options: ISerializePointOptions = {}): string {
+  const { precision = <grammar.TimePrecision>'n' } = options;
+  const { fields = {}, tags = {}, measurement, timestamp } = point;
+
+  const schema = options.schema && options.schema[measurement];
+  const fieldsPairs = schema ? schema.coerceFields(fields) : coerceBadly(fields);
+  const tagsNames = schema ? schema.checkTags(tags) : Object.keys(tags);
+
+  let line: string = measurement;
+
+  for (let i = 0; i < tagsNames.length; i += 1) {
+    line += ',' + grammar.escape.tag(tagsNames[i]) + '=' + grammar.escape.tag(tags[tagsNames[i]]);
+  }
+
+  for (let i = 0; i < fieldsPairs.length; i += 1) {
+    line += (i === 0 ? ' ' : ',') + grammar.escape.tag(fieldsPairs[i][0]) + '=' + fieldsPairs[i][1];
+  }
+
+  if (timestamp !== undefined) {
+    line += ' ' + grammar.castTimestamp(timestamp, precision);
+  }
+
+  return line;
+}

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -318,7 +318,7 @@ export class Pool {
             // the request options, wrapped in a conditional for even worse
             // polyfills. See: https://github.com/node-influx/node-influx/issues/221
             if (typeof req.setTimeout === 'function') {
-              req.setTimeout(timeout, fail); // tslint:disable-line
+              req.setTimeout(timeout, () => fail(null)); // tslint:disable-line
             }
 
             req.on('timeout', fail);

--- a/test/unit/line-protocol.test.ts
+++ b/test/unit/line-protocol.test.ts
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+
+import { FieldType } from '../../src';
+import { serializePoint } from '../../src/line-protocol';
+import { Schema } from '../../src/schema';
+
+describe('line-protocol', () => {
+  describe('serializePoint', () => {
+    it('serialises with defaults', () => {
+      const point = {
+        measurement: 'h2o_feet',
+        tags: { location: 'coyote_creek' },
+        fields: {
+          water_level: '8.120',
+          'level description': 'between 6 and 9 feet',
+        },
+        timestamp: new Date(1439856000 * 1000),
+      };
+      const line = serializePoint(point);
+
+      expect(line).to.equal(
+        'h2o_feet,location=coyote_creek level\\ description="between 6 and 9 feet",water_level="8.120" 1439856000000000000',
+      );
+    });
+
+    it('serialises with custom precision', () => {
+      const point = {
+        measurement: 'h2o_feet',
+        tags: { location: 'coyote_creek' },
+        fields: {
+          water_level: '8.120',
+          'level description': 'between 6 and 9 feet',
+        },
+        timestamp: new Date(1439856000 * 1000),
+      };
+      const line = serializePoint(point, { precision: 's' });
+
+      expect(line).to.equal(
+        'h2o_feet,location=coyote_creek level\\ description="between 6 and 9 feet",water_level="8.120" 1439856000',
+      );
+    });
+
+    it('serialises with custom schema', () => {
+      const point = {
+        measurement: 'my_schemed_measure',
+        tags: { my_tag: '1' },
+        fields: {
+          int: 42,
+          float: 43,
+          bool: true,
+        },
+      };
+
+      const measurementSchema = new Schema({
+        database: 'my_db',
+        measurement: 'h2o_feet',
+        tags: ['my_tag'],
+        fields: {
+          int: FieldType.INTEGER,
+          float: FieldType.FLOAT,
+          string: FieldType.STRING,
+          bool: FieldType.BOOLEAN,
+        },
+      });
+      const line = serializePoint(point, {
+        schema: { h2o_feet: measurementSchema },
+      });
+
+      expect(line).to.equal('my_schemed_measure,my_tag=1 bool=true,float=43,int=42');
+    });
+  });
+});


### PR DESCRIPTION
I'd like to be able to use the handy line protocol & schema stuff already implemented here to serialise points and toss them down a UDP socket.

UDP support in the library would be great, but using UDP is so simple that building it in is nearly YAGNI. The serialisation code is handy though, so may as well make it reusable.

## Notes
- The unit tests seemed to break with something unrelated to this PR and the Travis CI doesn't seem to be working, so I opted not to go out of scope for the this PR and fix.
- `tslint --fix` run as part of `npm run fmt`seemed to fix a lot of stuff all over the project, so I opted to leave that out of this PR. May be to do with tslint coming in from outside the project, or config or something.
- I added the `prettier` config to `package.json` so that my editor does the right thing on save.