### PR TITLE
escape measurement name in writePoints function

### DIFF
--- a/test/unit/influx.test.ts
+++ b/test/unit/influx.test.ts
@@ -183,13 +183,11 @@ describe('influxdb', () => {
         expect(pool[method]).to.have.been.calledWith({
           method: httpMethod,
           path: '/query',
-          query: Object.assign(
-            {
+          query: {
               u: 'root',
               p: 'root',
-            },
-            options,
-          ),
+            ...options,
+          },
         });
       });
     };
@@ -205,13 +203,11 @@ describe('influxdb', () => {
           method: 'POST',
           path: '/write',
           body,
-          query: Object.assign(
-            {
+          query: {
               u: 'root',
               p: 'root',
-            },
-            options,
-          ),
+            ...options,
+          },
         });
       });
     };
@@ -683,6 +679,48 @@ describe('influxdb', () => {
 
         return influx.writeMeasurement(
           'mymeas',
+          [
+            {
+              tags: { my_tag: '1' },
+              fields: { myfield: 90 },
+              timestamp: toNanoDate('1463683075000000000'),
+            },
+          ],
+          { precision: 'ms' },
+        );
+      });
+
+      it('escapes spaces in measurement', () => {
+        setDefaultDB('my_db');
+        expectWrite('my\\ meas,my_tag=1 myfield=90 1463683075000', {
+          precision: 'ms',
+          rp: undefined,
+          db: 'my_db',
+        });
+
+        return influx.writeMeasurement(
+          'my meas',
+          [
+            {
+              tags: { my_tag: '1' },
+              fields: { myfield: 90 },
+              timestamp: toNanoDate('1463683075000000000'),
+            },
+          ],
+          { precision: 'ms' },
+        );
+      });
+
+      it('escapes commans in measurement', () => {
+        setDefaultDB('my_db');
+        expectWrite('my\\,meas,my_tag=1 myfield=90 1463683075000', {
+          precision: 'ms',
+          rp: undefined,
+          db: 'my_db',
+        });
+
+        return influx.writeMeasurement(
+          'my,meas',
           [
             {
               tags: { my_tag: '1' },


### PR DESCRIPTION
5.0 Changelog says 

> data passed into Influx, except where otherwise noted, will be escaped automatically

Didn't find any statement on escaping in writePoints, v4.0 also was escaping, so I think readding this functionality makes sense.

Also fixes #331 