### PR TITLE
feat: mark typescript definition for host optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export interface IHostConfig {
 	/**
    * Influx host to connect to, defaults to 127.0.0.1.
    */
-	host: string;
+	host?: string;
 	/**
    * Influx port to connect to, defaults to 8086.
    */


### PR DESCRIPTION
It will default to 127.0.0.1

closes #318