### PR TITLE
Implement:  show shards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -790,8 +790,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
       "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
@@ -2466,8 +2465,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
       "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "cssstyle": {
       "version": "0.2.37",

--- a/package.json
+++ b/package.json
@@ -78,8 +78,7 @@
     "stream-http": "github:node-influx/stream-http",
     "ts-node": "8.3.0",
     "typescript": "3.5.2",
-    "webpack": "4.34.0",
-    "semantic-release": "15.13.16"
+    "webpack": "4.34.0"
   },
   "eslintConfig": {
     "extends": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1090,8 +1090,8 @@ export class InfluxDB {
 	*     },
 	*   ])
 	* })
-	*/
-	 public showShards(): Promise<IResults<{
+  */
+	public showShards(): Promise<IResults<{
 		id: number;
 		database: string;
 		retention_policy: string;
@@ -1100,18 +1100,18 @@ export class InfluxDB {
 		end_time: string;
 		expiry_time: string;
 		owners: string;
-	 }>> {
-		 return this._pool
-			 .json(
-				 this._getQueryOpts(
-					 {
+	}>> {
+		return this._pool
+			.json(
+				this._getQueryOpts(
+					{
 						q: 'show shards '
-					 },
-					 'GET',
-				 ),
-			 )
-			 .then(result =>
-				 parseSingle<{
+					},
+					'GET',
+				),
+			)
+			.then(result =>
+				parseSingle<{
 					id: number;
 					database: string;
 					retention_policy: string;
@@ -1120,9 +1120,9 @@ export class InfluxDB {
 					end_time: string;
 					expiry_time: string;
 					owners: string;
-				 }>(result),
-			 );
-	 }
+				}>(result),
+			);
+	}
 
 	/**
    * WritePoints sends a list of points together in a batch to InfluxDB. In

--- a/src/index.ts
+++ b/src/index.ts
@@ -1073,13 +1073,14 @@ export class InfluxDB {
 	/**
    * Shows shards on the database
    *
-   *
+   * @param [database] The database to list policies on, uses the
+   *     default database if not provided.
    * @return
    * @example
    * influx.showShards().then(shards => {
 	*   expect(shards.slice()).to.deep.equal([
 	*     {
-	*		id:
+	*		id: 1
 	*		database: 'database',
 	*		retention_policy: 'autogen',
 	*		shard_group: 1,
@@ -1091,7 +1092,7 @@ export class InfluxDB {
 	*   ])
 	* })
   */
-	public showShards(): Promise<IResults<{
+ public showShards(database: string = this._defaultDB()): Promise<Array<{
 		id: number;
 		database: string;
 		retention_policy: string;
@@ -1099,8 +1100,8 @@ export class InfluxDB {
 		start_time: string;
 		end_time: string;
 		expiry_time: string;
-		owners: string;
-	}>> {
+    owners: string;
+  }>>{
 		return this._pool
 			.json(
 				this._getQueryOpts(
@@ -1120,7 +1121,9 @@ export class InfluxDB {
 					end_time: string;
 					expiry_time: string;
 					owners: string;
-				}>(result),
+        }>(result).filter(function(i) {
+          return i.database === database;
+        })
 			);
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1071,6 +1071,60 @@ export class InfluxDB {
 	}
 
 	/**
+   * Shows shards on the database
+   *
+   *
+   * @return
+   * @example
+   * influx.showShards().then(shards => {
+	*   expect(shards.slice()).to.deep.equal([
+	*     {
+	*		id:
+	*		database: 'database',
+	*		retention_policy: 'autogen',
+	*		shard_group: 1,
+	*		start_time: '2019-05-06T00:00:00Z',
+	*		end_time: '2019-05-13T00:00:00Z',
+	*		expiry_time: '2019-05-13T00:00:00Z',
+	*		owners: null,
+	*     },
+	*   ])
+	* })
+	*/
+	 public showShards(): Promise<IResults<{
+		id: number;
+		database: string;
+		retention_policy: string;
+		shard_group: number;
+		start_time: string;
+		end_time: string;
+		expiry_time: string;
+		owners: string;
+	 }>> {
+		 return this._pool
+			 .json(
+				 this._getQueryOpts(
+					 {
+						q: 'show shards '
+					 },
+					 'GET',
+				 ),
+			 )
+			 .then(result =>
+				 parseSingle<{
+					id: number;
+					database: string;
+					retention_policy: string;
+					shard_group: number;
+					start_time: string;
+					end_time: string;
+					expiry_time: string;
+					owners: string;
+				 }>(result),
+			 );
+	 }
+
+	/**
    * WritePoints sends a list of points together in a batch to InfluxDB. In
    * each point you must specify the measurement name to write into as well
    * as a list of tag and field values. Optionally, you can specify the

--- a/test/create-fixtures.js
+++ b/test/create-fixtures.js
@@ -45,6 +45,8 @@ const queries = [
   update(`create retention policy "7d" on "${db}" duration 7d replication 1`),
   fixture('showRetentionPolicies', `show retention policies on "${db}"`),
 
+  fixture('showShards', 'show shards'),
+
   update(`drop user john`),
   update(`drop user steve`),
   update(`drop database "${db}"`)

--- a/test/fixture/v1.0.0/showShards.json
+++ b/test/fixture/v1.0.0/showShards.json
@@ -1,0 +1,47 @@
+{
+  "results": [
+    {
+      "statement_id": 0,
+      "series": [
+        {
+          "name": "_internal",
+          "columns": [
+            "id",
+            "database",
+            "retention_policy",
+            "shard_group",
+            "start_time",
+            "end_time",
+            "expiry_time",
+            "owners"
+          ],
+          "values": [
+            [
+              1,
+              "_internal",
+              "monitor",
+              1,
+              "2019-06-13T00:00:00Z",
+              "2019-06-14T00:00:00Z",
+              "2019-06-21T00:00:00Z",
+              ""
+            ]
+          ]
+        },
+        {
+          "name": "influx_test_gen",
+          "columns": [
+            "id",
+            "database",
+            "retention_policy",
+            "shard_group",
+            "start_time",
+            "end_time",
+            "expiry_time",
+            "owners"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/integrate/data.test.ts
+++ b/test/integrate/data.test.ts
@@ -18,6 +18,10 @@ describe('data operations', () => {
 
 	it('shows databases', () => {
 		return db.getDatabaseNames().then(res => expect(res).contain('influx_test_db'));
+  });
+
+  it('shows shards', () => {
+		return db.showShards('influx_test_db').then(res => expect(res[0]).to.have.property('database', 'influx_test_db' ));
 	});
 
 	it('writes complex values (issue #242)', () => {

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -18,6 +18,7 @@ const fixtures: { [version: string]: { [fixture: string]: object } } = {
 		showDatabases: require('../fixture/v1.0.0/showDatabases.json'),
 		showMeasurements: require('../fixture/v1.0.0/showMeasurements.json'),
 		showRetentionPolicies: require('../fixture/v1.0.0/showRetentionPolicies.json'),
+		showShards: require('../fixture/v1.0.0/showShards.json'),
 		showSeries: require('../fixture/v1.0.0/showSeries.json'),
 		showSeriesFromOne: require('../fixture/v1.0.0/showSeriesFromOne.json'),
 		showUsers: require('../fixture/v1.0.0/showUsers.json')

--- a/test/unit/influx.test.ts
+++ b/test/unit/influx.test.ts
@@ -884,7 +884,8 @@ describe('influxdb', () => {
 		});
 
 		it('shows shards', () => {
-			expectQuery('json', 'show shards ', 'GET', dbFixture('showShards'));
+      setDefaultDB('_internal');
+      expectQuery('json', 'show shards ', 'GET', dbFixture('showShards'));
 			return influx.showShards().then(res => {
 				expect(res.slice()).to.deep.equal([
 					{

--- a/test/unit/influx.test.ts
+++ b/test/unit/influx.test.ts
@@ -882,5 +882,23 @@ describe('influxdb', () => {
 				]);
 			});
 		});
+
+		it('shows shards', () => {
+			expectQuery('json', 'show shards ', 'GET', dbFixture('showShards'));
+			return influx.showShards().then(res => {
+				expect(res.slice()).to.deep.equal([
+					{
+						id: 1,
+						database: '_internal',
+						retention_policy: 'monitor',
+						shard_group: 1,
+						start_time: '2019-06-13T00:00:00Z',
+						end_time: '2019-06-14T00:00:00Z',
+						expiry_time: '2019-06-21T00:00:00Z',
+						owners: ''
+					}
+				]);
+			});
+		});
 	});
 });


### PR DESCRIPTION
Fixes #

Since `show shards` doesn't have a `ON` specifier this returns all shards to be filtered in your own code.

See here for the support of `SHOW SHARD ON <DB>`
https://github.com/influxdata/influxdb/issues/7353 

Please review and any comments are welcome.
If this is working will be implementing also: `DROP SHARD <NUMBER>` with a method like `.dropShard(<number>)`

But first start with the basics.

## Proposed Changes

  - add method for calling show shards

## Checklist

- [x ] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)