### PR TITLE
feat: allow schema to be specified at runtime

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -436,22 +436,18 @@ export class InfluxDB {
 			this._pool.addHost(`${host.protocol}://${host.host}:${host.port}`, host.options);
 		});
 
-		this._options.schema.forEach(schema => {
-			schema.database = schema.database || this._options.database;
-			const db = schema.database;
-			if (!db) {
-				throw new Error(
-					`Schema ${schema.measurement} doesn't have a database specified,` +
-            'and no default database is provided!',
-				);
-			}
+		this._options.schema.forEach(schema => this.createSchema(schema));	
+	}
 
-			if (!this._schema[db]) {
-				this._schema[db] = Object.create(null);
-			}
 
-			this._schema[db][schema.measurement] = new Schema(schema);
-		});
+   /**
+    * Adds specified schema for better fields coercing.
+    *
+    * @param {ISchemaOptions} schema
+    * @memberof InfluxDB
+    */
+	public addSchema (schema: ISchemaOptions): void {
+		this.createSchema(schema);
 	}
 
 	/**
@@ -1313,5 +1309,27 @@ export class InfluxDB {
 				...params
 			}
 		};
-	}
+   }
+   
+   /**
+   * Creates specified measurement schema
+   *
+   * @private
+   * @param {ISchemaOptions} schema
+   * @memberof InfluxDB
+   */
+	private createSchema (schema: ISchemaOptions) {
+		const db = schema.database = schema.database || this._options.database;
+		if (!db) {
+			throw new Error(
+				`Schema ${schema.measurement} doesn't have a database specified,` +
+				'and no default database is provided!',
+			);
+		}
+		if (!this._schema[db]) {
+			this._schema[db] = Object.create(null);
+		}
+
+		this._schema[db][schema.measurement] = new Schema(schema);
+ 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -436,18 +436,17 @@ export class InfluxDB {
 			this._pool.addHost(`${host.protocol}://${host.host}:${host.port}`, host.options);
 		});
 
-		this._options.schema.forEach(schema => this.createSchema(schema));	
+		this._options.schema.forEach(schema => this._createSchema(schema));
 	}
 
-
-   /**
-    * Adds specified schema for better fields coercing.
-    *
-    * @param {ISchemaOptions} schema
-    * @memberof InfluxDB
-    */
-	public addSchema (schema: ISchemaOptions): void {
-		this.createSchema(schema);
+  /**
+   * Adds specified schema for better fields coercing.
+   *
+   * @param {ISchemaOptions} schema
+   * @memberof InfluxDB
+   */
+	public addSchema(schema: ISchemaOptions): void {
+		this._createSchema(schema);
 	}
 
 	/**
@@ -1309,8 +1308,8 @@ export class InfluxDB {
 				...params
 			}
 		};
-   }
-   
+	}
+
    /**
    * Creates specified measurement schema
    *
@@ -1318,18 +1317,19 @@ export class InfluxDB {
    * @param {ISchemaOptions} schema
    * @memberof InfluxDB
    */
-	private createSchema (schema: ISchemaOptions) {
-		const db = schema.database = schema.database || this._options.database;
-		if (!db) {
+	private _createSchema(schema: ISchemaOptions): void {
+		schema.database = schema.database || this._options.database;
+		if (!schema.database) {
 			throw new Error(
 				`Schema ${schema.measurement} doesn't have a database specified,` +
 				'and no default database is provided!',
 			);
-		}
-		if (!this._schema[db]) {
-			this._schema[db] = Object.create(null);
+    }
+
+		if (!this._schema[schema.database]) {
+			this._schema[schema.database] = Object.create(null);
 		}
 
-		this._schema[db][schema.measurement] = new Schema(schema);
- 	}
+		this._schema[schema.database][schema.measurement] = new Schema(schema);
+	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -439,7 +439,7 @@ export class InfluxDB {
 		this._options.schema.forEach(schema => this._createSchema(schema));
 	}
 
-  /**
+	/**
    * Adds specified schema for better fields coercing.
    *
    * @param {ISchemaOptions} schema
@@ -1310,7 +1310,7 @@ export class InfluxDB {
 		};
 	}
 
-   /**
+	/**
    * Creates specified measurement schema
    *
    * @private
@@ -1324,7 +1324,7 @@ export class InfluxDB {
 				`Schema ${schema.measurement} doesn't have a database specified,` +
 				'and no default database is provided!',
 			);
-    }
+		}
 
 		if (!this._schema[schema.database]) {
 			this._schema[schema.database] = Object.create(null);

--- a/test/unit/influx.test.ts
+++ b/test/unit/influx.test.ts
@@ -552,6 +552,37 @@ describe('influxdb', () => {
 				]);
 			});
 
+			it('can accept a schema at runtime', () => {
+				setDefaultDB('my_db');
+				expectWrite('my_runtime_schema_measure,my_tag=1 bool=T,float=43,int=42i', {
+					precision: 'n',
+					rp: undefined,
+					db: 'my_db'
+				});
+
+				influx.addSchema({
+					database: 'my_db',
+					measurement: 'my_runtime_schema_measure',
+					fields: {
+						bool: FieldType.BOOLEAN,
+						float: FieldType.FLOAT,
+						int: FieldType.INTEGER
+					},
+					tags: ['my_tag']
+				});
+				return influx.writePoints([
+					{
+						measurement: 'my_runtime_schema_measure',
+						tags: {my_tag: '1'},
+						fields: {
+							int: 42,
+							float: 43,
+							bool: true
+						}
+					}
+				]);
+			});
+
 			it('throws on schema violations', () => {
 				setDefaultDB('my_db');
 


### PR DESCRIPTION
Fixes #311 - rebases stale changes from @flafik as per https://github.com/node-influx/node-influx/pull/311#issuecomment-497952278

## Proposed Changes
 - Allow a schema to be added to the `InfluxDB` object at runtime i.e. after the object has been initialised.  This makes field coercion work where the name of the database or measurement is not known prior to writing the points.

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)