### PR TITLE
fix: bring editorconfig inline with eslint rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,5 @@ charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
 end_of_line = lf
-indent_style = space
+indent_style = tab
 indent_size = 2


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Replace space by tab in editorconfig, since eslint is checking for tabs
  -
  -

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)