### PR TITLE
fix: correct return type of getDatabaseNames()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -498,7 +498,7 @@ export class InfluxDB {
    * influx.getDatabaseNames().then(names =>
    *   console.log('My database names are: ' + names.join(', ')));
    */
-	public getDatabaseNames(): Promise<string | string[]> {
+	public getDatabaseNames(): Promise<string[]> {
 		return this._pool
 			.json(this._getQueryOpts({q: 'show databases'}))
 			.then(res => parseSingle<{ name: string }>(res).map(r => r.name));


### PR DESCRIPTION
## Proposed Changes

  - Fix the return type of `InfluxDB.getDatabaseNames()` according to its document
  - This revision doesn't need to update any test files.

## Checklist

- [ ] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)