### PR TITLE
Add 'path' configuration option for host

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {coerceBadly, ISchemaOptions, Schema} from './schema';
 const defaultHost: IHostConfig = Object.freeze({
 	host: '127.0.0.1',
 	port: 8086,
+	path: '',
 	protocol: 'http' as 'http'
 });
 
@@ -40,6 +41,11 @@ export interface IHostConfig {
    * Influx port to connect to, defaults to 8086.
    */
 	port?: number;
+	/**
+   * Path for Influx within the host, defaults to ''.
+   * May be used if Influx is behind a reverse proxy or load balancer.
+   */
+	path?: string;
 	/**
    * Protocol to connect over, defaults to 'http'.
    */
@@ -422,6 +428,7 @@ export class InfluxDB {
 				{
 					host: host.host,
 					port: host.port,
+					path: host.path,
 					protocol: host.protocol,
 					options: host.options
 				},
@@ -433,7 +440,7 @@ export class InfluxDB {
 		this._options = defaults(resolved, defaultOptions);
 
 		resolved.hosts.forEach(host => {
-			this._pool.addHost(`${host.protocol}://${host.host}:${host.port}`, host.options);
+			this._pool.addHost(`${host.protocol}://${host.host}:${host.port}${host.path}`, host.options);
 		});
 
 		this._options.schema.forEach(schema => this._createSchema(schema));

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -349,13 +349,15 @@ export class Pool {
 			return callback(new ServiceNotAvailableError('No host available'), null);
 		}
 
-		let path = options.path;
+		const once = doOnce();
+		const host = this._getHost();
+
+		let path = host.url.pathname === '/' ? '' : host.url.pathname;
+		path += options.path;
 		if (options.query) {
 			path += '?' + querystring.stringify(options.query);
 		}
 
-		const once = doOnce();
-		const host = this._getHost();
 		const req = request(
 			{
 				headers: {'content-length': options.body ? Buffer.from(options.body).length : 0},

--- a/test/unit/influx.test.ts
+++ b/test/unit/influx.test.ts
@@ -21,6 +21,7 @@ describe('influxdb', () => {
 					{
 						host: '127.0.0.1',
 						port: 8086,
+						path: '',
 						protocol: 'http',
 						options: undefined
 					}
@@ -41,6 +42,7 @@ describe('influxdb', () => {
 					{
 						host: '192.168.0.1',
 						port: 1337,
+						path: '',
 						protocol: 'https',
 						options: undefined
 					}
@@ -59,6 +61,7 @@ describe('influxdb', () => {
 					{
 						host: '192.168.0.1',
 						port: 8086,
+						path: '',
 						protocol: 'http',
 						options: undefined
 					}
@@ -81,6 +84,7 @@ describe('influxdb', () => {
 					{
 						host: '192.168.0.1',
 						port: 8086,
+						path: '',
 						protocol: 'http',
 						options: {ca: null}
 					}

--- a/test/unit/pool.test.ts
+++ b/test/unit/pool.test.ts
@@ -65,14 +65,14 @@ describe('pool', () => {
 
 	it('attempts to make an https request', () => {
 		const p = createPool();
-		p.addHost('https://httpbin.org/get');
+		p.addHost('https://httpbin.org');
 		return p.json({method: 'GET', path: '/get'});
 	});
 
 	it('passes through request options', () => {
 		const spy = sinon.spy(https, 'request');
 		const p = createPool();
-		p.addHost('https://httpbin.org/get', {rejectUnauthorized: false});
+		p.addHost('https://httpbin.org', {rejectUnauthorized: false});
 
 		return p.json({method: 'GET', path: '/get'}).then(() => {
 			expect((spy.args[0][0] as any).rejectUnauthorized).to.be.false;
@@ -82,7 +82,7 @@ describe('pool', () => {
 	it('valid request data content length', () => {
 		const p = createPool();
 		const body = '\u00FF';
-		p.addHost('https://httpbin.org/post');
+		p.addHost('https://httpbin.org');
 		p
 			.json({method: 'POST', path: '/post', body: body})
 			.then(data => expect(data.data).to.equal(body));


### PR DESCRIPTION
May be used if Influx is behind a reverse proxy or load balancer

Fixes #324 
I came across the same issue as described in this ticket. This PR provides a solution for this.

## Proposed Changes
  - Added optional `path` to host configuration. Default to empty string. Path is expected to start with a "/"
  - `path` is added to the host URL for API calls
  - I updated the tests as required
  - I didn't add a test but I tested it with my server. Not sure how we could add a unit test, as in default InfluxDB installs, the path is empty.
  - The path cannot be specified when passing the host configuration as a string. I thought it would be confusing since in that format, the path contains the database name.

## Checklist

- [ ] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)