### PR TITLE
Consume ping responses

### DIFF
--- a/src/pool.ts
+++ b/src/pool.ts
@@ -300,7 +300,7 @@ export class Pool {
 							once((res: http.IncomingMessage) => {
 								resolve({
 									url,
-									res,
+									res: res.resume(),
 									online: res.statusCode < 300,
 									rtt: Date.now() - start,
 									version: res.headers['x-influxdb-version']


### PR DESCRIPTION
Fixes #475 

## Proposed Changes

  - The influx ping responses are consumed


## Checklist

- [ ] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)