### PR TITLE
fix: abort requests on timeout

### DIFF
--- a/src/pool.ts
+++ b/src/pool.ts
@@ -309,6 +309,7 @@ export class Pool {
 						);
 
 						const fail = once(() => {
+							req.abort();
 							resolve({
 								online: false,
 								res: null,
@@ -400,6 +401,7 @@ export class Pool {
 		req.on(
 			'timeout',
 			once(() => {
+				req.abort();
 				this._handleRequestError(
 					new ServiceNotAvailableError('Request timed out'),
 					host,


### PR DESCRIPTION
Fixes #494

## Proposed Changes

  - HTTP requests are aborted on timeout in both `ping` and `stream` methods.

## Checklist

- [ ] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)