### PR TITLE
fix: fix timestamps rounding in INanoDate

### DIFF
--- a/src/grammar/times.ts
+++ b/src/grammar/times.ts
@@ -263,7 +263,11 @@ const nanoDateMethods = {
  * expect(date.toNanoISOString()).to.equal('2016-10-09T03:58:00.231035600Z');
  */
 export function toNanoDate(timestamp: string): INanoDate {
-  const date = new Date(Math.floor(Number(timestamp) / nsPer.ms)) as any;
+  const secs = Math.floor(Number(timestamp) / nsPer.s);
+  const remainingNs = timestamp.slice(String(secs).length);
+  const remainingMs = Number(remainingNs) / nsPer.ms;
+  const date = new Date(0) as any;
+  date.setUTCSeconds(secs, remainingMs);
   date._nanoTime = timestamp;
   date.getNanoTime = nanoDateMethods.getNanoTimeFromStamp;
   date.toNanoISOString = nanoDateMethods.toNanoISOStringFromStamp;

--- a/test/unit/grammar.test.ts
+++ b/test/unit/grammar.test.ts
@@ -50,6 +50,13 @@ describe("grammar", () => {
     expect(date.toNanoISOString()).to.equal("2016-10-09T03:58:00.231035600Z");
   });
 
+  it("converts a nanoseconds timestamp with trailing zeroes to a nano date", () => {
+    const date = grammar.toNanoDate("1254646541002000000");
+    expect(date.getTime()).to.equal(1254646541002);
+    expect(date.getNanoTime()).to.equal("1254646541002000000"); // Precision is lost
+    expect(date.toNanoISOString()).to.equal("2009-10-04T08:55:41.002000000Z");
+  });
+
   describe("formatting", () => {
     it("formats nanosecond dates", () => {
       expect(grammar.formatDate(nanoDate)).to.equal(


### PR DESCRIPTION
Fixes #487

## Proposed Changes
- issue related to floating-point arithmetics in JS.
- first proposal was to use third-party [big.js](https://github.com/MikeMcl/big.js), but actually could manage a workaround based on string parsing.
---

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
