### PR TITLE
517

### DIFF
--- a/src/grammar/escape.ts
+++ b/src/grammar/escape.ts
@@ -60,7 +60,7 @@ class Escaper {
 
     let match;
 
-    if (typeof val === 'string') {
+    if (typeof val === "string") {
       val = val.replace(/\\'/, "\\\\'");
     }
 

--- a/src/grammar/escape.ts
+++ b/src/grammar/escape.ts
@@ -60,7 +60,9 @@ class Escaper {
 
     let match;
 
-    val = val.replace(/\\'/, "\\\\'");
+    if (typeof val === 'string') {
+      val = val.replace(/\\'/, "\\\\'");
+    }
 
     /* eslint-disable no-cond-assign */
     while ((match = this._re.exec(val))) {

--- a/test/unit/grammar.test.ts
+++ b/test/unit/grammar.test.ts
@@ -21,11 +21,12 @@ describe("grammar", () => {
     ).to.equal('don"t escape');
   });
 
-  it("escapes backslashes (issue #486)", () => {
+  it("escapes backslashes (issues #486, #516)", () => {
     // eslint-disable-next-line quotes
     expect(grammar.escape.stringLit("GAZP()\\' or 1=1 --")).to.equal(
       "'GAZP()\\\\\\' or 1=1 --'"
     );
+    expect(grammar.escape.tag(1 as any)).to.equal('1');
   });
 
   it("escapes complex values (issue #242)", () => {

--- a/test/unit/grammar.test.ts
+++ b/test/unit/grammar.test.ts
@@ -26,7 +26,7 @@ describe("grammar", () => {
     expect(grammar.escape.stringLit("GAZP()\\' or 1=1 --")).to.equal(
       "'GAZP()\\\\\\' or 1=1 --'"
     );
-    expect(grammar.escape.tag(1 as any)).to.equal('1');
+    expect(grammar.escape.tag(1 as any)).to.equal("1");
   });
 
   it("escapes complex values (issue #242)", () => {


### PR DESCRIPTION
Fixes #517 Lint Errors

## Proposed Changes

- #517
- Fixes lint errors

## Checklist

- [x] A test has been added if appropriate
- [ ] `npm test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
