### PR TITLE
fix: proper encoding for response in pool (#521)

### DIFF
--- a/src/pool.ts
+++ b/src/pool.ts
@@ -377,6 +377,7 @@ export class Pool {
         ...host.options,
       },
       once((res: http.IncomingMessage) => {
+        res.setEncoding("utf8");
         if (res.statusCode >= 500) {
           return this._handleRequestError(
             new ServiceNotAvailableError(res.statusMessage),

--- a/test/unit/pool.test.ts
+++ b/test/unit/pool.test.ts
@@ -88,6 +88,15 @@ describe("pool", () => {
     );
   });
 
+  it("handles unicode chunks correctly", () => {
+    const p = createPool();
+    const body = "درود".repeat(40960);
+    p.addHost("https://httpbin.org");
+    p.json({ method: "POST", path: "/post", body: body }).then((data) =>
+      expect(data.data).to.equal(body)
+    );
+  });
+
   describe("request generators", () => {
     it("makes a text request", () => {
       return pool


### PR DESCRIPTION
Fixes #521

## Proposed Changes
Set response encoding to `utf8`, so string concentration when multiple chunks are received would work as expected.

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
