### PR TITLE
fix: consume response on http 500 errors

### DIFF
--- a/src/pool.ts
+++ b/src/pool.ts
@@ -379,12 +379,20 @@ export class Pool {
       once((res: http.IncomingMessage) => {
         res.setEncoding("utf8");
         if (res.statusCode >= 500) {
-          return this._handleRequestError(
-            new ServiceNotAvailableError(res.statusMessage),
-            host,
-            options,
-            callback
-          );
+          res.on("data", () => {
+            /* ignore */
+          });
+
+          res.on("end", () => {
+            return this._handleRequestError(
+              new ServiceNotAvailableError(res.statusMessage),
+              host,
+              options,
+              callback
+            );
+          });
+
+          return;
         }
 
         if (res.statusCode >= 300) {


### PR DESCRIPTION
Fixes #542

## Proposed Changes

  - Consume response body on HTTP errors with status code >= 500
  - Call stream callback only after response has been fully consumed

---

## Checklist

- [ ] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
