### PR TITLE
fix: don't disable pool host if backoff is zero

### DIFF
--- a/src/backoff/constant.ts
+++ b/src/backoff/constant.ts
@@ -1,0 +1,66 @@
+import { IBackoffStrategy } from "./backoff";
+
+/**
+ * IConstantOptions are passed into the ConstantBackoff constructor. The
+ * backoff equation is, the simplest possible, a constant delay with an
+ * optional jitter, delay*(1-random_jitter) and delay*(1+random_jitter).
+ *
+ */
+export interface IConstantOptions {
+  /**
+   * The constant delay passed to the equation.
+   */
+  delay: number;
+
+  /**
+   * Random factor between 0 and 1 to avoid the thundering herd problem.
+   */
+  jitter?: number;
+}
+
+/**
+ * Constant Backoff
+ */
+export class ConstantBackoff implements IBackoffStrategy {
+  protected options: IConstantOptions;
+
+  /**
+   * Creates a new constant backoff strategy.
+   * @param options
+   */
+  constructor(options: IConstantOptions) {
+    this.options = {
+      delay: Math.max(options.delay, 0),
+      jitter: Math.min(Math.max(options.jitter || 0, 0), 1),
+    };
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public getDelay(): number {
+    let delay: number = this.options.delay;
+
+    if (this.options.jitter > 0) {
+      const min = delay * (1 - this.options.jitter);
+      const max = delay * (1 + this.options.jitter);
+      delay = Math.random() * (max - min) + min;
+    }
+
+    return delay;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public next(): IBackoffStrategy {
+    return this;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public reset(): IBackoffStrategy {
+    return this;
+  }
+}

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -466,11 +466,15 @@ export class Pool {
    * re-enabled after a backoff interval
    */
   private _disableHost(host: Host): void {
-    this._hostsAvailable.delete(host);
-    this._hostsDisabled.add(host);
-    this._index %= Math.max(1, this._hostsAvailable.size);
+    const delay = host.fail();
 
-    setTimeout(() => this._enableHost(host), host.fail());
+    if (delay > 0) {
+      this._hostsAvailable.delete(host);
+      this._hostsDisabled.add(host);
+      this._index %= Math.max(1, this._hostsAvailable.size);
+
+      setTimeout(() => this._enableHost(host), delay);
+    }
   }
 
   private _handleRequestError(

--- a/test/unit/backoff.test.ts
+++ b/test/unit/backoff.test.ts
@@ -3,9 +3,41 @@
 import { expect } from "chai";
 
 import { IBackoffStrategy } from "../../src/backoff/backoff";
+import { ConstantBackoff } from "../../src/backoff/constant";
 import { ExponentialBackoff } from "../../src/backoff/exponential";
 
 describe("backoff strategies", () => {
+  describe("constant strategy", () => {
+    it("appears to work", () => {
+      let exp: IBackoffStrategy = new ConstantBackoff({
+        delay: 500,
+        jitter: 0.5,
+      });
+
+      function next(): number {
+        const value = exp.getDelay();
+        exp = exp.next();
+        return value;
+      }
+
+      const checkSequence = (): void => {
+        expect(next()).to.be.within(500 * (1 - 0.5), 500 * (1 + 0.5));
+        expect(next()).to.be.within(500 * (1 - 0.5), 500 * (1 + 0.5));
+        expect(next()).to.be.within(500 * (1 - 0.5), 500 * (1 + 0.5));
+        expect(next()).to.be.within(500 * (1 - 0.5), 500 * (1 + 0.5));
+        expect(next()).to.be.within(500 * (1 - 0.5), 500 * (1 + 0.5));
+        expect(next()).to.be.within(500 * (1 - 0.5), 500 * (1 + 0.5));
+      };
+
+      checkSequence();
+      exp = exp.reset();
+      const dupe = exp.reset();
+      checkSequence();
+      exp = dupe;
+      checkSequence();
+    });
+  });
+
   describe("exponential strategy", () => {
     it("appears to work", () => {
       let exp: IBackoffStrategy = new ExponentialBackoff({


### PR DESCRIPTION
Fixes #544 

## Proposed Changes

  - Check if host should be disabled. It's keep enabled if `host.fail()` (which calls the backoff getter) returns zero. It will only disable the host if this value is greater than zero.
  - Add a constant backoff strategy as an alternative to the default exponential backoff. This was required to simplify test creation, but it also adds value for users that don't need exponential strategies.
  - Create tests for ConstantBackoff class and add two tests for the Pool class to show the changed behaviour.

---

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
