### PR TITLE
ci: checkout pull request head

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,9 +21,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-        with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
 
       - name: Prettier
         uses: creyD/prettier_action@v3.0


### PR DESCRIPTION
Fixes Github Actions CI workflow

## Proposed Changes

  - Remove commit SHA reference from `actions/checkout@v2` as is not required. Pushes on master will reference latest commit SHA and PRs will reference the merge commit.

---

## Checklist

- [ ] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
