### PR TITLE
ci: restrict release workflow to upstream repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-18.04
+    if: github.repository == 'node-influx/node-influx'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Kudos @bencevans for that fast migration to GH Actions!

Fix release workflows being executed on forks (they always fail, but waste user minutes).

## Proposed Changes

  - Restrict execution of release workflow based on repository name.

---

## Checklist

- [ ] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
