### PR TITLE
#560 - Expose a "point validation" function

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -34,10 +34,16 @@ module.exports = function (config) {
      * Webpack and bundling config:
      */
     webpack: require("./webpack.config"),
-    webpackServer: { noInfo: true },
-    webpackMiddleware: { stats: "errors-only" },
+    webpackServer: {
+      noInfo: true,
+    },
+    webpackMiddleware: {
+      stats: "errors-only",
+    },
     files: ["test/karma.shim.js"],
-    preprocessors: { "test/karma.shim.js": ["sourcemap", "webpack"] },
+    preprocessors: {
+      "test/karma.shim.js": ["sourcemap", "webpack"],
+    },
     middleware: ["pool-tests"],
 
     /**


### PR DESCRIPTION
## Proposed Changes
Currently, the logic for validating a point is embedded in the InfluxDB.writePoints function. I am proposing to extract that logic out to a separate function on the InfluxDB instance so it will be used by InfluxDB.writePoints, but is also accessible externally for optional manual schema/coercion validation of a given point *before* being sent to InfluxDB.writePoints. This can be beneficial for "pre-processing" a batch of data to determine which points are valid and which are not, so they can be dealt with accordingly. This gives the user the flexibility to decide how validation is done and what to do if a data point is invalid.

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
