### PR TITLE
feat: support authentication in ping method

### DIFF
--- a/examples/testing.md
+++ b/examples/testing.md
@@ -1,9 +1,17 @@
 # Testing
 
-`influx` is tested primarily with a suite of unit tests in additional to functional tests which require an InfluxDB instance to run. The recommended way of running Influx is use their official Docker image:
+`influx` is tested primarily with a suite of unit tests in additional to functional tests which require an InfluxDB instance to run. In order to check authentication related tests, the InfluxDB instance must have both HTTP and `/ping` authentication enabled and a `root:root` user must exist.
+
+The recommended way of running Influx is use their official Docker image:
 
 ```
-docker run -d -p 8083:8083 -p 8086:8086 --expose 8090 --expose 8099 influxdb
+docker run -d --name influxdb \
+  -p 8083:8083 -p 8086:8086 --expose 8090 --expose 8099 \
+  -e INFLUXDB_HTTP_AUTH_ENABLED=true \
+  -e INFLUXDB_HTTP_PING_AUTH_ENABLED=true \
+  influxdb:1.8
+
+docker exec influxdb influx -execute "CREATE USER root WITH PASSWORD 'root' WITH ALL PRIVILEGES"
 ```
 
 Alternately, you can use a local installation of the package. If you would like to contribute and don't want to set up a full Influx testing environment, you can run solely unit tests and linting via `npm-run-all test:unit test:lint`, which do not require anything other than an `npm install`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1545,7 +1545,13 @@ export class InfluxDB {
    * })
    */
   public ping(timeout: number): Promise<IPingStats[]> {
-    return this._pool.ping(timeout);
+    let auth: string = undefined;
+
+    if (typeof this._options.username === "string") {
+      auth = `${this._options.username}:${this._options.password || ""}`;
+    }
+
+    return this._pool.ping(timeout, "/ping", auth);
   }
 
   /**

--- a/test/integrate/admin.test.ts
+++ b/test/integrate/admin.test.ts
@@ -17,7 +17,11 @@ describe("administrative actions", () => {
     const expectUser = (name: string, admin: boolean): Promise<void> => {
       return db
         .getUsers()
-        .then((users) => expect(users).to.deep.equal([{ user: name, admin }]))
+        .then((users) =>
+          expect(users.filter((value) => value.user === name)).to.deep.equal([
+            { user: name, admin },
+          ])
+        )
         .then(() => undefined);
     };
 


### PR DESCRIPTION
Fixes #578

## Proposed Changes

Add `Authorization` header to `ping` methods if `username` and `password` options have been defined.

No tests are required, as `ping` was already being tested. However, I did add some clarifications in the docs to suggest that testing should be done with authentication enabled and a `root` user created. Also, a fix has been included in a test helper method that checked the existence of an user. It was failing if other users existed besides the one being checked.

---

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)