### PR TITLE
fix: #539 Incorrect encoding when using placeholders / bind parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1513,7 +1513,7 @@ export class InfluxDB {
         epoch: options.precision,
         q: query,
         rp: retentionPolicy,
-        params: placeholders,
+        params: JSON.stringify(placeholders),
       })
     );
   }

--- a/test/unit/influx.test.ts
+++ b/test/unit/influx.test.ts
@@ -876,7 +876,7 @@ describe("influxdb", () => {
             epoch: undefined,
             rp: undefined,
             db: "my_db",
-            params: {},
+            params: "{}",
           },
           "GET",
           dbFixture("selectFromOne")
@@ -895,7 +895,7 @@ describe("influxdb", () => {
             epoch: undefined,
             rp: undefined,
             db: "my_db",
-            params: {},
+            params: "{}",
           },
           "GET",
           dbFixture("selectFromOne")
@@ -925,7 +925,7 @@ describe("influxdb", () => {
             epoch: undefined,
             rp: undefined,
             db: "my_db",
-            params: {},
+            params: "{}",
           },
           "GET",
           dbFixture("selectFromOne")
@@ -945,7 +945,7 @@ describe("influxdb", () => {
             epoch: "ms",
             rp: "asdf",
             db: "my_db",
-            params: {},
+            params: "{}",
           },
           "GET",
           dbFixture("selectFromOne")
@@ -965,7 +965,7 @@ describe("influxdb", () => {
             epoch: undefined,
             rp: "asdf",
             db: "my_db",
-            params: {},
+            params: "{}",
           },
           "GET",
           dbFixture("selectFromOne")
@@ -985,7 +985,7 @@ describe("influxdb", () => {
             epoch: undefined,
             rp: "asdf",
             db: "my_db",
-            params: { since: "10s" },
+            params: '{"since":"10s"}',
           },
           "GET",
           dbFixture("selectFromOne")


### PR DESCRIPTION
Fixes #539 

---

## Checklist

- [ x ] A test has been added if appropriate
- [ x ] `npm test` completes successfully
- [ x ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
