### PR TITLE
fix: #587 Placeholders / bind parameters support for number variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,7 @@ export interface IQueryOptions {
    * Any placeholders used by the query. Using these is strongly recommended
    * to avoid injection attacks.
    */
-  placeholders?: Record<string, string>;
+  placeholders?: Record<string, string | number>;
 }
 
 export interface IParseOptions {

--- a/test/unit/influx.test.ts
+++ b/test/unit/influx.test.ts
@@ -981,23 +981,26 @@ describe("influxdb", () => {
         expectQuery(
           "json",
           {
-            q: "select * from series_0 WHERE time > now() - $<since>",
+            q: "select * from series_0 WHERE time > now() - $<since> AND value >= $<minimumValue>",
             epoch: undefined,
             rp: "asdf",
             db: "my_db",
-            params: '{"since":"10s"}',
+            params: '{"since":"10s","minimumValue":12}',
           },
           "GET",
           dbFixture("selectFromOne")
         );
 
         return influx.query(
-          ["select * from series_0 WHERE time > now() - $<since>"],
+          [
+            "select * from series_0 WHERE time > now() - $<since> AND value >= $<minimumValue>",
+          ],
           {
             precision: "n",
             retentionPolicy: "asdf",
             placeholders: {
               since: "10s",
+              minimumValue: 12,
             },
           }
         );


### PR DESCRIPTION
Fixes #587

## Proposed Changes

Placeholders / bind parameters support for number variables

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
