### PR TITLE
fix: #606 - Timestamp conversion subject to floating point errors

### DIFF
--- a/src/grammar/times.ts
+++ b/src/grammar/times.ts
@@ -348,7 +348,7 @@ class NanosecondsDateManipulator implements IDateManipulator<INanoDate> {
       case "u":
         timestamp *= 1000;
       case "n": {
-        const date = new Date(timestamp / nsPer.ms) as any;
+        const date = new Date(Math.round(timestamp / nsPer.ms)) as any;
         date._nanoTime = String(timestamp);
         date.getNanoTime = nanoDateMethods.getNanoTimeFromStamp;
         date.toNanoISOString = nanoDateMethods.toNanoISOStringFromStamp;

--- a/test/unit/grammar.test.ts
+++ b/test/unit/grammar.test.ts
@@ -93,6 +93,12 @@ describe("grammar", () => {
       );
     });
 
+    it("accounts for floating point errors", () => {
+      const parsed = grammar.isoOrTimeToDate(1638842483690000000, "n");
+      expect(parsed.getTime()).to.equal(1638842483690);
+      expect(parsed.toISOString()).to.equal("2021-12-07T02:01:23.690Z");
+    });
+
     it("parses numeric `u` timestamps", () => {
       const parsed = grammar.isoOrTimeToDate(1475985480231035, "u");
       expect(parsed.getTime()).to.equal(1475985480231);


### PR DESCRIPTION
Fixes #606

## Proposed Changes

Correct issues caused by floating point errors when converting nano timestamps to ms

---

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
