### PR TITLE
fix: improve time field typing in query results

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1442,9 +1442,9 @@ export class InfluxDB {
   public query<T>(
     query: string[],
     options?: IQueryOptions
-  ): Promise<Array<IResults<T>>>;
+  ): Promise<Array<IResults<T & {time: grammar.INanoDate}>>>;
 
-  public query<T>(query: string, options?: IQueryOptions): Promise<IResults<T>>;
+  public query<T>(query: string, options?: IQueryOptions): Promise<IResults<T & {time: grammar.INanoDate}>>;
 
   /**
    * .query() runs a query (or list of queries), and returns the results in a
@@ -1462,7 +1462,7 @@ export class InfluxDB {
   public query<T>(
     query: string | string[],
     options: IQueryOptions = {}
-  ): Promise<IResults<T> | Array<IResults<T>>> {
+  ): Promise<IResults<T & {time: grammar.INanoDate}> | Array<IResults<T & {time: grammar.INanoDate}>>> {
     if (Array.isArray(query)) {
       query = query.join(";");
     }

--- a/src/results.ts
+++ b/src/results.ts
@@ -1,3 +1,4 @@
+import type { INanoDate } from "./grammar";
 import { isoOrTimeToDate, TimePrecision } from "./grammar";
 
 /**
@@ -217,7 +218,7 @@ export function assertNoErrors(res: IResponse): IResponse {
 export function parse<T>(
   res: IResponse,
   precision?: TimePrecision
-): Array<IResults<T>> | IResults<T> {
+): Array<IResults<T & {time: INanoDate}>> | IResults<T & {time: INanoDate}> {
   assertNoErrors(res);
 
   if (res.results.length === 1) {


### PR DESCRIPTION
### What is this?
Current type definitions for query results lack proper typing for the time field, which can lead to type-safety issues when working with time-series data. This PR adds proper typing to ensure the time field is correctly typed as `INanoDate` throughout the codebase.

### Changes
#### Code Changes:
1. **In `index.ts`**:
  - Update return type of `query` method overloads to include `time: grammar.INanoDate`
  - Modify generic type parameter to include time field type information

2. **In `results.ts`**:
  - Update `parse` function return type to include `time: INanoDate` in generic type parameter
  - **Note**: `parseInner` function still uses `any` and should be updated with proper type hints. If this is merged, I'll spend some time to properly type that function as well.

### Context
This improves TypeScript type safety when working with time series data in InfluxDB queries. Without proper typing, consumers of the library might encounter type issues when accessing the time field in query results.

---

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](t)
