### PR TITLE
feat: add capability to query with POST requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16700,6 +16700,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import * as url from "url";
 
 import * as b from "./builder";
 import * as grammar from "./grammar";
+import * as querystring from "querystring";
 import { IPingStats, IPoolOptions, Pool } from "./pool";
 import { assertNoErrors, IResults, parse, parseSingle } from "./results";
 import { coerceBadly, ISchemaOptions, Schema } from "./schema";
@@ -206,6 +207,11 @@ export interface IQueryOptions {
    * to avoid injection attacks.
    */
   placeholders?: Record<string, string | number>;
+
+  /**
+   * Execute a query as a HTTP GET or POST request
+   */
+  method?: "GET" | "POST";
 }
 
 export interface IParseOptions {
@@ -1514,13 +1520,17 @@ export class InfluxDB {
     }
 
     return this._pool.json(
-      this._getQueryOpts({
-        db: database,
-        epoch: options.precision,
-        q: query,
-        rp: retentionPolicy,
-        params: JSON.stringify(placeholders),
-      })
+      this._getQueryOpts(
+        {
+          db: database,
+          epoch: options.precision,
+          q: query,
+          rp: retentionPolicy,
+          params: JSON.stringify(placeholders),
+        },
+        options.method,
+        true,
+      ),
     );
   }
 
@@ -1569,16 +1579,26 @@ export class InfluxDB {
    * Creates options to be passed into the pool to query databases.
    * @private
    */
-  private _getQueryOpts(params: any, method = "GET"): any {
-    return {
-      method,
-      path: "/query",
-      query: {
-        p: this._options.password,
-        u: this._options.username,
-        ...params,
-      },
+  private _getQueryOpts(params: any, method = "GET", partOfBody = false): any {
+    const query = {
+      u: this._options.username,
+      p: this._options.password,
+      ...params,
     };
+
+    if (method === "POST" && partOfBody) {
+      return {
+        method,
+        path: "/query",
+        body: querystring.stringify(query),
+      };
+    } else {
+      return {
+        method,
+        path: "/query",
+        query,
+      };
+    }
   }
 
   /**

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -378,6 +378,9 @@ export class Pool {
       {
         headers: {
           "content-length": options.body ? Buffer.from(options.body).length : 0,
+          ...(options.body
+            ? { "Content-Type": "application/x-www-form-urlencoded" }
+            : {}),
         },
         hostname: host.url.hostname,
         method: options.method,

--- a/test/integrate/data.test.ts
+++ b/test/integrate/data.test.ts
@@ -55,6 +55,20 @@ describe("data operations", () => {
     });
   });
 
+  it("queries with POST request", () => {
+    const expected = ["2015-08-18T00:48:00Z", 56, "coyote_creek", "3"];
+    return db
+      .queryRaw(
+        "SELECT * FROM h2o_quality WHERE time = '2015-08-18T00:48:00Z'",
+        {
+          method: "POST",
+        },
+      )
+      .then((res) => {
+        expect(res.results[0].series[0].values[0]).to.deep.equal(expected);
+      });
+  });
+
   it("drops series", () => {
     return db
       .dropSeries({

--- a/test/unit/influx.test.ts
+++ b/test/unit/influx.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
+import * as querystring from "querystring";
 
 import { FieldType, InfluxDB, toNanoDate } from "../../src";
 import { Pool } from "../../src/pool";
@@ -181,7 +182,8 @@ describe("influxdb", () => {
       method: keyof Pool,
       options: string | any,
       httpMethod: string = "POST",
-      yields: any = { results: [{}] }
+      yields: any = { results: [{}] },
+      hasBody = false,
     ): void => {
       if (typeof options === "string") {
         options = { q: options };
@@ -189,15 +191,24 @@ describe("influxdb", () => {
 
       (pool[method] as any).returns(Promise.resolve(yields));
       expectations.push(() => {
-        expect(pool[method]).to.have.been.calledWith({
+        const baseParams = {
+          u: "root",
+          p: "root",
+          ...options,
+        };
+
+        const callOptions: any = {
           method: httpMethod,
           path: "/query",
-          query: {
-            u: "root",
-            p: "root",
-            ...options,
-          },
-        });
+        };
+
+        if (hasBody) {
+          callOptions.body = querystring.stringify(baseParams);
+        } else {
+          callOptions.query = baseParams;
+        }
+
+        expect(pool[method]).to.have.been.calledWith(callOptions);
       });
     };
 
@@ -1002,8 +1013,31 @@ describe("influxdb", () => {
               since: "10s",
               minimumValue: 12,
             },
-          }
+          },
         );
+      });
+
+      it("queryRaw with POST request", () => {
+        expectQuery(
+          "json",
+          {
+            db: "my_db",
+            epoch: undefined,
+            q: "select * from series_0",
+            rp: undefined,
+            params: "{}",
+          },
+          "POST",
+          dbFixture("selectFromOne"),
+          true,
+        );
+        return influx
+          .queryRaw("select * from series_0", {
+            method: "POST",
+          })
+          .then((res) => {
+            expect(res).to.deep.equal(dbFixture("selectFromOne"));
+          });
       });
     });
 


### PR DESCRIPTION
This feature allows users to invoke `query` and `queryRaw` as POST requests.

Fixes #676

## Proposed Changes

- Support for [executing queries as POST requests](https://docs.influxdata.com/influxdb/v1/guides/query_data/#query-data-with-influxql)
- Extended `IQueryOptions` with a `method` property
- Extended `_getQueryOpts` to be able to pass down properties for POST request
- Extended `Pool.stream` to include `Content-Type` header in case of `options.body` set
- Added unit and integration test

---

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
