### PR TITLE
feat: default to Basic Auth header; stop sending creds in URL/query

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1343,11 +1343,13 @@ export class InfluxDB {
       path: "/write",
       query: {
         db: database,
-        p: this._options.password,
         precision,
         rp: retentionPolicy,
-        u: this._options.username,
       },
+      auth:
+        typeof this._options.username === "string"
+          ? `${this._options.username}:${this._options.password || ""}`
+          : undefined,
     });
   }
 
@@ -1580,26 +1582,26 @@ export class InfluxDB {
    * @private
    */
   private _getQueryOpts(params: any, method = "GET", partOfBody = false): any {
-    const authCredentials = {
-      u: this._options.username,
-      p: this._options.password,
+    let auth: string = undefined;
+    if (typeof this._options.username === "string") {
+      auth = `${this._options.username}:${this._options.password || ""}`;
     }
 
     if (method === "POST" && partOfBody) {
       return {
         method,
         path: "/query",
-        query: authCredentials,
+        auth,
         body: querystring.stringify(params),
       };
     } else {
       return {
         method,
         path: "/query",
+        auth,
         query: {
-          ...authCredentials,
-          ...params
-        }
+          ...params,
+        },
       };
     }
   }

--- a/test/fixture/pool-middleware.js
+++ b/test/fixture/pool-middleware.js
@@ -70,6 +70,15 @@ module.exports = function () {
         });
         break;
 
+      case "echo-headers":
+        res.end(
+          JSON.stringify({
+            headers: req.headers,
+            url: url,
+          })
+        );
+        break;
+
       case "json":
         res.end(JSON.stringify({ ok: true }));
         break;

--- a/test/unit/influx.test.ts
+++ b/test/unit/influx.test.ts
@@ -191,21 +191,16 @@ describe("influxdb", () => {
 
       (pool[method] as any).returns(Promise.resolve(yields));
       expectations.push(() => {
-        const authParams = {
-          u: "root",
-          p: "root",
-        };
-
         const callOptions: any = {
           method: httpMethod,
           path: "/query",
+          auth: "root:root",
         };
 
         if (hasBody) {
-          callOptions.query = authParams;
           callOptions.body = querystring.stringify(options);
         } else {
-          callOptions.query = { ...authParams, ...options };
+          callOptions.query = { ...options };
         }
 
         expect(pool[method]).to.have.been.calledWith(callOptions);
@@ -224,10 +219,9 @@ describe("influxdb", () => {
           path: "/write",
           body,
           query: {
-            u: "root",
-            p: "root",
             ...options,
           },
+          auth: "root:root",
         });
       });
     };

--- a/test/unit/pool.test.ts
+++ b/test/unit/pool.test.ts
@@ -135,6 +135,16 @@ describe("pool", () => {
         .then((data) => expect(data).to.deep.equal({ ok: true }));
     });
 
+    it("sends Basic Authorization header when auth is set", () => {
+      const auth = "user:pass";
+      const expected = Buffer.from(auth).toString("base64");
+      return pool
+        .json({ method: "GET", path: "/pool/echo-headers", auth })
+        .then((data) => {
+          expect(data.headers["authorization"]).to.equal(`Basic ${expected}`);
+        });
+    });
+
     it("errors if JSON parsing fails", () => {
       return pool
         .json({ method: "GET", path: "/pool/badjson" })


### PR DESCRIPTION
This feature replaces sending credentials in URL by using basic authentication in HTTP header.

Fixes #264, #323 

Initial test confirm it now [works with QuestDB](https://community.questdb.com/t/is-there-a-way-to-write-to-questdb-with-node-red/875/21?u=pdeng). Since this could be a breaking change for some people, I would like to ask the wider community to test and improve this PR.

## Proposed Changes
- Remove credentials from connecting url
- Added basic authentication in http header
- Basic authentication is the default
- Modified tests
---

## Checklist

- [x] A test has been added if appropriate
- [x] `npm test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
